### PR TITLE
don't pin to an exact pandas version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10.7"
 dependencies = [
     "sgqlc",
     "openai",
-    "pandas==1.5.1"
+    "pandas>=1.5.1"
 ]
 
 [build-system]


### PR DESCRIPTION
Updates pandas dependency to be anything >=1.5.1 rather than exactly that version.