### PR TITLE
add setting user id header for internal auth

### DIFF
--- a/answer_rocket/auth.py
+++ b/answer_rocket/auth.py
@@ -33,14 +33,15 @@ class ExternalAuthHelper(AuthHelper):
 class InternalAuthHelper(AuthHelper):
 	url: str
 	tenant: str
-	user: str
+	user: str | None
 
 	def headers(self) -> dict:
 		headers = {
 			'Max-Tenant': self.tenant,
 			'Authorization': 'Max-Internal',
-			'Max-User': self.user,
 		}
+		if self.user:
+			headers['Max-User'] = self.user
 		return headers
 	
 

--- a/answer_rocket/auth.py
+++ b/answer_rocket/auth.py
@@ -33,11 +33,13 @@ class ExternalAuthHelper(AuthHelper):
 class InternalAuthHelper(AuthHelper):
 	url: str
 	tenant: str
+	user: str
 
 	def headers(self) -> dict:
 		headers = {
 			'Max-Tenant': self.tenant,
-			'Authorization': 'Max-Internal'
+			'Authorization': 'Max-Internal',
+			'Max-User': self.user,
 		}
 		return headers
 	
@@ -50,4 +52,5 @@ def init_auth_helper(url: Optional[str], token: Optional[str]) -> AuthHelper:
 	if token:
 		return ExternalAuthHelper(url=url, token=token)
 	tenant = os.getenv('AR_TENANT_ID')
-	return InternalAuthHelper(url=url, tenant=tenant)
+	user = os.getenv('AR_USER_ID')
+	return InternalAuthHelper(url=url, tenant=tenant, user=user)


### PR DESCRIPTION
This ensures the requests made with the sdk internally have a user id attached if one is available. In the case where a token is provided the token itself takes care of that.