### PR TITLE
add queries and mutations to facilitate handling a chat thread

### DIFF
--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -149,7 +149,6 @@ class Chat:
 
         return False, str(last_error)
 
-
     def ask_question(self, copilot_id: str, question: str, thread_id: str = None, skip_report_cache: bool = False, dry_run_type: str = None):
         """
         Calls the Max chat pipeline to answer a natural language question and receive analysis and insights
@@ -264,6 +263,56 @@ class Chat:
 
         return result.evaluate_chat_question
 
+    def get_chat_entry(self, entry_id: str):
+        get_chat_entry_args = {
+            'id': UUID(entry_id),
+        }
+
+        op = Operations.query.chat_entry
+        result = self.gql_client.submit(op, get_chat_entry_args)
+        return result.chat_entry
+
+    def get_chat_thread(self, thread_id: str):
+        get_chat_thread_args = {
+            'id': UUID(thread_id),
+        }
+
+        op = Operations.query.chat_thread
+        result = self.gql_client.submit(op, get_chat_thread_args)
+        return result.chat_thread
+
+    def create_new_thread(self, copilot_id: str):
+        create_chat_thread_args = {
+            'copilotId': copilot_id,
+        }
+
+        op = Operations.mutation.create_chat_thread
+        result = self.gql_client.submit(op, create_chat_thread_args)
+        return result.create_chat_thread
+
+    def queue_chat_question(self, question: str, thread_id: str, skip_cache: bool = False):
+        queue_chat_question_args = {
+            'question': question,
+            'skipCache': skip_cache,
+            'threadId': thread_id
+        }
+
+        op = Operations.mutation.queue_chat_question
+
+        result = self.gql_client.submit(op, queue_chat_question_args)
+
+        return result.queue_chat_question
+
+    def cancel_chat_question(self, entry_id: str):
+        cancel_chat_question_args = {
+            'entryId': entry_id,
+        }
+
+        op = Operations.mutation.cancel_chat_question
+
+        result = self.gql_client.submit(op, cancel_chat_question_args)
+
+        return result.cancel_chat_question
 
 
 def _create_llm_config_fragments():

--- a/answer_rocket/graphql/operations/chat.gql
+++ b/answer_rocket/graphql/operations/chat.gql
@@ -16,31 +16,90 @@ mutation AskChatQuestion(
         id
         threadId
         answer {
-            answerId
-            answeredAt
-            copilotSkillId
-            hasFinished
-            error
-            isNewThread
-            message
-            reportResults {
-                id
-                title
-                reportName
-                runId
-                parameters {
-                    key
-                    values
-                    label
-                }
-                contentBlocks {
-                    id
-                    title
-                    payload
-                }
-            }
-            threadId
-            userId
+            ...ChatResultFragment
         }
+    }
+}
+
+mutation QueueChatQuestion(
+    $threadId: UUID!
+    $question: String!
+    $skipCache: Boolean
+) {
+    queueChatQuestion(
+        threadId: $threadId,
+        question: $question,
+        skipCache: $skipCache,
+    ) {
+        threadId
+        id
+    }
+}
+
+fragment ChatResultFragment on MaxChatResult {
+    answerId
+    answeredAt
+    copilotSkillId
+    hasFinished
+    error
+    isNewThread
+    message
+    reportResults {
+        id
+        title
+        reportName
+        runId
+        parameters {
+            key
+            values
+            label
+        }
+        contentBlocks {
+            id
+            title
+            payload
+        }
+    }
+    threadId
+    userId
+}
+
+mutation CancelChatQuestion(
+    $entryId: UUID!
+) {
+    cancelChatQuestion(entryId: $entryId) {
+        threadId
+        id
+    }
+}
+
+query ChatEntry(
+    $id: UUID!
+) {
+    chatEntry(id: $id) {
+        id
+        threadId
+        answer {
+            ...ChatResultFragment
+        }
+    }
+}
+
+query ChatThread($id: UUID!) {
+    chatThread(id: $id) {
+        id
+        entryCount
+        title
+        copilotId
+        entries {
+            ...ChatResultFragment
+        }
+    }
+}
+
+mutation CreateChatThread($copilotId: UUID!) {
+    createChatThread(copilotId: $copilotId) {
+        id
+        copilotId
     }
 }

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -147,49 +147,6 @@ class MaxDomainEntity(sgqlc.types.Interface):
     attributes = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxDomainAttribute))), graphql_name='attributes')
 
 
-class ChatEntry(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('id', 'thread_id', 'answer')
-    id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='id')
-    thread_id = sgqlc.types.Field(UUID, graphql_name='threadId')
-    answer = sgqlc.types.Field('ChatResult', graphql_name='answer')
-
-
-class ChatResult(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('answer_id', 'answered_at', 'copilot_skill_id', 'has_finished', 'error', 'is_new_thread', 'message', 'report_results', 'thread_id', 'user_id')
-    answer_id = sgqlc.types.Field(UUID, graphql_name='answerId')
-    answered_at = sgqlc.types.Field(DateTime, graphql_name='answeredAt')
-    copilot_skill_id = sgqlc.types.Field(UUID, graphql_name='copilotSkillId')
-    has_finished = sgqlc.types.Field(Boolean, graphql_name='hasFinished')
-    error = sgqlc.types.Field(String, graphql_name='error')
-    is_new_thread = sgqlc.types.Field(Boolean, graphql_name='isNewThread')
-    message = sgqlc.types.Field(String, graphql_name='message')
-    report_results = sgqlc.types.Field(sgqlc.types.list_of(sgqlc.types.non_null('ReportResult')), graphql_name='reportResults')
-    thread_id = sgqlc.types.Field(UUID, graphql_name='threadId')
-    user_id = sgqlc.types.Field(UUID, graphql_name='userId')
-
-
-class ChatThread(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('id', 'entry_count', 'title', 'pinned_dataset')
-    id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='id')
-    entry_count = sgqlc.types.Field(Int, graphql_name='entryCount', args=sgqlc.types.ArgDict((
-        ('most_recent_entry_inclusive', sgqlc.types.Arg(UUID, graphql_name='mostRecentEntryInclusive', default=None)),
-))
-    )
-    title = sgqlc.types.Field(String, graphql_name='title')
-    pinned_dataset = sgqlc.types.Field(UUID, graphql_name='pinnedDataset')
-
-
-class ContentBlock(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('id', 'title', 'payload')
-    id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='id')
-    title = sgqlc.types.Field(String, graphql_name='title')
-    payload = sgqlc.types.Field(String, graphql_name='payload')
-
-
 class CopilotSkillArtifact(sgqlc.types.Type):
     __schema__ = schema
     __field_names__ = ('copilot_skill_artifact_id', 'copilot_id', 'copilot_skill_id', 'artifact_path', 'artifact', 'description', 'created_user_id', 'created_utc', 'last_modified_user_id', 'last_modified_utc', 'version', 'is_active', 'is_deleted')
@@ -290,6 +247,40 @@ class ExecuteSqlQueryResponse(sgqlc.types.Type):
     data = sgqlc.types.Field(JSON, graphql_name='data')
 
 
+class MaxChatEntry(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('id', 'thread_id', 'answer')
+    id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='id')
+    thread_id = sgqlc.types.Field(UUID, graphql_name='threadId')
+    answer = sgqlc.types.Field('MaxChatResult', graphql_name='answer')
+
+
+class MaxChatResult(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('answer_id', 'answered_at', 'copilot_skill_id', 'has_finished', 'error', 'is_new_thread', 'message', 'report_results', 'thread_id', 'user_id')
+    answer_id = sgqlc.types.Field(UUID, graphql_name='answerId')
+    answered_at = sgqlc.types.Field(DateTime, graphql_name='answeredAt')
+    copilot_skill_id = sgqlc.types.Field(UUID, graphql_name='copilotSkillId')
+    has_finished = sgqlc.types.Field(Boolean, graphql_name='hasFinished')
+    error = sgqlc.types.Field(String, graphql_name='error')
+    is_new_thread = sgqlc.types.Field(Boolean, graphql_name='isNewThread')
+    message = sgqlc.types.Field(String, graphql_name='message')
+    report_results = sgqlc.types.Field(sgqlc.types.list_of(sgqlc.types.non_null('MaxReportResult')), graphql_name='reportResults')
+    thread_id = sgqlc.types.Field(UUID, graphql_name='threadId')
+    user_id = sgqlc.types.Field(UUID, graphql_name='userId')
+
+
+class MaxChatThread(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('id', 'entry_count', 'title', 'pinned_dataset', 'copilot_id', 'entries')
+    id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='id')
+    entry_count = sgqlc.types.Field(Int, graphql_name='entryCount')
+    title = sgqlc.types.Field(String, graphql_name='title')
+    pinned_dataset = sgqlc.types.Field(UUID, graphql_name='pinnedDataset')
+    copilot_id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='copilotId')
+    entries = sgqlc.types.Field(sgqlc.types.list_of(MaxChatEntry), graphql_name='entries')
+
+
 class MaxColumn(sgqlc.types.Type):
     __schema__ = schema
     __field_names__ = ('name', 'jdbc_type', 'length', 'precision', 'scale')
@@ -298,6 +289,14 @@ class MaxColumn(sgqlc.types.Type):
     length = sgqlc.types.Field(Int, graphql_name='length')
     precision = sgqlc.types.Field(Int, graphql_name='precision')
     scale = sgqlc.types.Field(Int, graphql_name='scale')
+
+
+class MaxContentBlock(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('id', 'title', 'payload')
+    id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='id')
+    title = sgqlc.types.Field(String, graphql_name='title')
+    payload = sgqlc.types.Field(String, graphql_name='payload')
 
 
 class MaxCopilot(sgqlc.types.Type):
@@ -427,6 +426,27 @@ class MaxMutationResponse(sgqlc.types.Type):
     error = sgqlc.types.Field(String, graphql_name='error')
 
 
+class MaxReportParamsAndValues(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('key', 'values', 'label', 'type', 'color')
+    key = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='key')
+    values = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(String))), graphql_name='values')
+    label = sgqlc.types.Field(String, graphql_name='label')
+    type = sgqlc.types.Field(String, graphql_name='type')
+    color = sgqlc.types.Field(String, graphql_name='color')
+
+
+class MaxReportResult(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('id', 'title', 'report_name', 'run_id', 'parameters', 'content_blocks')
+    id = sgqlc.types.Field(UUID, graphql_name='id')
+    title = sgqlc.types.Field(String, graphql_name='title')
+    report_name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='reportName')
+    run_id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='runId')
+    parameters = sgqlc.types.Field(sgqlc.types.list_of(sgqlc.types.non_null(MaxReportParamsAndValues)), graphql_name='parameters')
+    content_blocks = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxContentBlock))), graphql_name='contentBlocks')
+
+
 class MaxTable(sgqlc.types.Type):
     __schema__ = schema
     __field_names__ = ('name', 'columns')
@@ -436,7 +456,7 @@ class MaxTable(sgqlc.types.Type):
 
 class Mutation(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('create_max_copilot_skill_chat_question', 'update_max_copilot_skill_chat_question', 'delete_max_copilot_skill_chat_question', 'create_max_copilot_question', 'update_max_copilot_question', 'delete_max_copilot_question', 'update_chat_answer_payload', 'ask_chat_question', 'evaluate_chat_question')
+    __field_names__ = ('create_max_copilot_skill_chat_question', 'update_max_copilot_skill_chat_question', 'delete_max_copilot_skill_chat_question', 'create_max_copilot_question', 'update_max_copilot_question', 'delete_max_copilot_question', 'update_chat_answer_payload', 'ask_chat_question', 'evaluate_chat_question', 'queue_chat_question', 'cancel_chat_question', 'create_chat_thread')
     create_max_copilot_skill_chat_question = sgqlc.types.Field(sgqlc.types.non_null(CreateMaxCopilotSkillChatQuestionResponse), graphql_name='createMaxCopilotSkillChatQuestion', args=sgqlc.types.ArgDict((
         ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
         ('copilot_skill_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotSkillId', default=None)),
@@ -479,7 +499,7 @@ class Mutation(sgqlc.types.Type):
         ('payload', sgqlc.types.Arg(sgqlc.types.non_null(JSON), graphql_name='payload', default=None)),
 ))
     )
-    ask_chat_question = sgqlc.types.Field(ChatEntry, graphql_name='askChatQuestion', args=sgqlc.types.ArgDict((
+    ask_chat_question = sgqlc.types.Field(MaxChatEntry, graphql_name='askChatQuestion', args=sgqlc.types.ArgDict((
         ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
         ('question', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='question', default=None)),
         ('thread_id', sgqlc.types.Arg(UUID, graphql_name='threadId', default=None)),
@@ -492,11 +512,25 @@ class Mutation(sgqlc.types.Type):
         ('evals', sgqlc.types.Arg(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(String))), graphql_name='evals', default=None)),
 ))
     )
+    queue_chat_question = sgqlc.types.Field(MaxChatEntry, graphql_name='queueChatQuestion', args=sgqlc.types.ArgDict((
+        ('thread_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='threadId', default=None)),
+        ('question', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='question', default=None)),
+        ('skip_cache', sgqlc.types.Arg(Boolean, graphql_name='skipCache', default=None)),
+))
+    )
+    cancel_chat_question = sgqlc.types.Field(MaxChatEntry, graphql_name='cancelChatQuestion', args=sgqlc.types.ArgDict((
+        ('entry_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='entryId', default=None)),
+))
+    )
+    create_chat_thread = sgqlc.types.Field(MaxChatThread, graphql_name='createChatThread', args=sgqlc.types.ArgDict((
+        ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
+))
+    )
 
 
 class Query(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('ping', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'llmapi_config_for_sdk', 'user_chat_threads', 'user_chat_entries')
+    __field_names__ = ('ping', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'llmapi_config_for_sdk', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry')
     ping = sgqlc.types.Field(String, graphql_name='ping')
     get_copilot_skill_artifact_by_path = sgqlc.types.Field(CopilotSkillArtifact, graphql_name='getCopilotSkillArtifactByPath', args=sgqlc.types.ArgDict((
         ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
@@ -570,27 +604,14 @@ class Query(sgqlc.types.Type):
         ('limit', sgqlc.types.Arg(Int, graphql_name='limit', default=None)),
 ))
     )
-
-
-class ReportParamsAndValues(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('key', 'values', 'label', 'type', 'color')
-    key = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='key')
-    values = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(String))), graphql_name='values')
-    label = sgqlc.types.Field(String, graphql_name='label')
-    type = sgqlc.types.Field(String, graphql_name='type')
-    color = sgqlc.types.Field(String, graphql_name='color')
-
-
-class ReportResult(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('id', 'title', 'report_name', 'run_id', 'parameters', 'content_blocks')
-    id = sgqlc.types.Field(UUID, graphql_name='id')
-    title = sgqlc.types.Field(String, graphql_name='title')
-    report_name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='reportName')
-    run_id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='runId')
-    parameters = sgqlc.types.Field(sgqlc.types.list_of(sgqlc.types.non_null(ReportParamsAndValues)), graphql_name='parameters')
-    content_blocks = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(ContentBlock))), graphql_name='contentBlocks')
+    chat_thread = sgqlc.types.Field(MaxChatThread, graphql_name='chatThread', args=sgqlc.types.ArgDict((
+        ('id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='id', default=None)),
+))
+    )
+    chat_entry = sgqlc.types.Field(MaxChatEntry, graphql_name='chatEntry', args=sgqlc.types.ArgDict((
+        ('id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='id', default=None)),
+))
+    )
 
 
 class AzureOpenaiCompletionLLMApiConfig(sgqlc.types.Type, LLMApiConfig):

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -8,40 +8,106 @@ _schema_root = _schema.schema
 __all__ = ('Operations',)
 
 
+def fragment_chat_result_fragment():
+    _frag = sgqlc.operation.Fragment(_schema.MaxChatResult, 'ChatResultFragment')
+    _frag.answer_id()
+    _frag.answered_at()
+    _frag.copilot_skill_id()
+    _frag.has_finished()
+    _frag.error()
+    _frag.is_new_thread()
+    _frag.message()
+    _frag_report_results = _frag.report_results()
+    _frag_report_results.id()
+    _frag_report_results.title()
+    _frag_report_results.report_name()
+    _frag_report_results.run_id()
+    _frag_report_results_parameters = _frag_report_results.parameters()
+    _frag_report_results_parameters.key()
+    _frag_report_results_parameters.values()
+    _frag_report_results_parameters.label()
+    _frag_report_results_content_blocks = _frag_report_results.content_blocks()
+    _frag_report_results_content_blocks.id()
+    _frag_report_results_content_blocks.title()
+    _frag_report_results_content_blocks.payload()
+    _frag.thread_id()
+    _frag.user_id()
+    return _frag
+
+
+class Fragment:
+    chat_result_fragment = fragment_chat_result_fragment()
+
+
 def mutation_ask_chat_question():
     _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='AskChatQuestion', variables=dict(copilotId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), question=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), threadId=sgqlc.types.Arg(_schema.UUID), skipReportCache=sgqlc.types.Arg(_schema.Boolean), dryRunType=sgqlc.types.Arg(_schema.ChatDryRunType)))
     _op_ask_chat_question = _op.ask_chat_question(copilot_id=sgqlc.types.Variable('copilotId'), question=sgqlc.types.Variable('question'), thread_id=sgqlc.types.Variable('threadId'), skip_report_cache=sgqlc.types.Variable('skipReportCache'), dry_run_type=sgqlc.types.Variable('dryRunType'))
     _op_ask_chat_question.id()
     _op_ask_chat_question.thread_id()
     _op_ask_chat_question_answer = _op_ask_chat_question.answer()
-    _op_ask_chat_question_answer.answer_id()
-    _op_ask_chat_question_answer.answered_at()
-    _op_ask_chat_question_answer.copilot_skill_id()
-    _op_ask_chat_question_answer.has_finished()
-    _op_ask_chat_question_answer.error()
-    _op_ask_chat_question_answer.is_new_thread()
-    _op_ask_chat_question_answer.message()
-    _op_ask_chat_question_answer_report_results = _op_ask_chat_question_answer.report_results()
-    _op_ask_chat_question_answer_report_results.id()
-    _op_ask_chat_question_answer_report_results.title()
-    _op_ask_chat_question_answer_report_results.report_name()
-    _op_ask_chat_question_answer_report_results.run_id()
-    _op_ask_chat_question_answer_report_results_parameters = _op_ask_chat_question_answer_report_results.parameters()
-    _op_ask_chat_question_answer_report_results_parameters.key()
-    _op_ask_chat_question_answer_report_results_parameters.values()
-    _op_ask_chat_question_answer_report_results_parameters.label()
-    _op_ask_chat_question_answer_report_results_content_blocks = _op_ask_chat_question_answer_report_results.content_blocks()
-    _op_ask_chat_question_answer_report_results_content_blocks.id()
-    _op_ask_chat_question_answer_report_results_content_blocks.title()
-    _op_ask_chat_question_answer_report_results_content_blocks.payload()
-    _op_ask_chat_question_answer.thread_id()
-    _op_ask_chat_question_answer.user_id()
+    _op_ask_chat_question_answer.__fragment__(fragment_chat_result_fragment())
+    return _op
+
+
+def mutation_queue_chat_question():
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='QueueChatQuestion', variables=dict(threadId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), question=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), skipCache=sgqlc.types.Arg(_schema.Boolean)))
+    _op_queue_chat_question = _op.queue_chat_question(thread_id=sgqlc.types.Variable('threadId'), question=sgqlc.types.Variable('question'), skip_cache=sgqlc.types.Variable('skipCache'))
+    _op_queue_chat_question.thread_id()
+    _op_queue_chat_question.id()
+    return _op
+
+
+def mutation_cancel_chat_question():
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='CancelChatQuestion', variables=dict(entryId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID))))
+    _op_cancel_chat_question = _op.cancel_chat_question(entry_id=sgqlc.types.Variable('entryId'))
+    _op_cancel_chat_question.thread_id()
+    _op_cancel_chat_question.id()
+    return _op
+
+
+def mutation_create_chat_thread():
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='CreateChatThread', variables=dict(copilotId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID))))
+    _op_create_chat_thread = _op.create_chat_thread(copilot_id=sgqlc.types.Variable('copilotId'))
+    _op_create_chat_thread.id()
+    _op_create_chat_thread.copilot_id()
     return _op
 
 
 class Mutation:
     ask_chat_question = mutation_ask_chat_question()
+    cancel_chat_question = mutation_cancel_chat_question()
+    create_chat_thread = mutation_create_chat_thread()
+    queue_chat_question = mutation_queue_chat_question()
+
+
+def query_chat_entry():
+    _op = sgqlc.operation.Operation(_schema_root.query_type, name='ChatEntry', variables=dict(id=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID))))
+    _op_chat_entry = _op.chat_entry(id=sgqlc.types.Variable('id'))
+    _op_chat_entry.id()
+    _op_chat_entry.thread_id()
+    _op_chat_entry_answer = _op_chat_entry.answer()
+    _op_chat_entry_answer.__fragment__(fragment_chat_result_fragment())
+    return _op
+
+
+def query_chat_thread():
+    _op = sgqlc.operation.Operation(_schema_root.query_type, name='ChatThread', variables=dict(id=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID))))
+    _op_chat_thread = _op.chat_thread(id=sgqlc.types.Variable('id'))
+    _op_chat_thread.id()
+    _op_chat_thread.entry_count()
+    _op_chat_thread.title()
+    _op_chat_thread.copilot_id()
+    _op_chat_thread_entries = _op_chat_thread.entries()
+    _op_chat_thread_entries.__fragment__(fragment_chat_result_fragment())
+    return _op
+
+
+class Query:
+    chat_entry = query_chat_entry()
+    chat_thread = query_chat_thread()
 
 
 class Operations:
+    fragment = Fragment
     mutation = Mutation
+    query = Query


### PR DESCRIPTION
This adds a few mutations and queries needed to manage chat interactions entirely via this client.

- `get_chat_entry` and `get_chat_thread`
- `create_new_thread`
- `queue_chat_question`: this differs from the existing mutation in that the resolver returns immediately after kicking off the question processing rather than waiting around for it. The new entry query can be used to check on its status via the returned entry id
- `cancel_chat_question`: kills the question job if possible and deletes the entry