### PR TITLE
fix incorrect query for chatThread

### DIFF
--- a/answer_rocket/graphql/operations/chat.gql
+++ b/answer_rocket/graphql/operations/chat.gql
@@ -86,7 +86,11 @@ query ChatThread($id: UUID!) {
         title
         copilotId
         entries {
-            ...ChatResultFragment
+            id
+            threadId
+            answer {
+                ...ChatResultFragment
+            }
         }
     }
 }

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -450,6 +450,14 @@ class MaxTable(sgqlc.types.Type):
     columns = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxColumn))), graphql_name='columns')
 
 
+class MaxUser(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('first_name', 'last_name', 'email_address')
+    first_name = sgqlc.types.Field(String, graphql_name='firstName')
+    last_name = sgqlc.types.Field(String, graphql_name='lastName')
+    email_address = sgqlc.types.Field(String, graphql_name='emailAddress')
+
+
 class Mutation(sgqlc.types.Type):
     __schema__ = schema
     __field_names__ = ('create_max_copilot_skill_chat_question', 'update_max_copilot_skill_chat_question', 'delete_max_copilot_skill_chat_question', 'create_max_copilot_question', 'update_max_copilot_question', 'delete_max_copilot_question', 'update_chat_answer_payload', 'ask_chat_question', 'evaluate_chat_question', 'queue_chat_question', 'cancel_chat_question', 'create_chat_thread')
@@ -526,8 +534,9 @@ class Mutation(sgqlc.types.Type):
 
 class Query(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('ping', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'llmapi_config_for_sdk', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry')
+    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'llmapi_config_for_sdk', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry')
     ping = sgqlc.types.Field(String, graphql_name='ping')
+    current_user = sgqlc.types.Field(MaxUser, graphql_name='currentUser')
     get_copilot_skill_artifact_by_path = sgqlc.types.Field(CopilotSkillArtifact, graphql_name='getCopilotSkillArtifactByPath', args=sgqlc.types.ArgDict((
         ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
         ('copilot_skill_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotSkillId', default=None)),

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -93,7 +93,10 @@ def query_chat_thread():
     _op_chat_thread.title()
     _op_chat_thread.copilot_id()
     _op_chat_thread_entries = _op_chat_thread.entries()
-    _op_chat_thread_entries.__fragment__(fragment_chat_result_fragment())
+    _op_chat_thread_entries.id()
+    _op_chat_thread_entries.thread_id()
+    _op_chat_thread_entries_answer = _op_chat_thread_entries.answer()
+    _op_chat_thread_entries_answer.__fragment__(fragment_chat_result_fragment())
     return _op
 
 


### PR DESCRIPTION
Corrects a bad query definition for `chatThread`. `entries` had the result fragment in it directly rather than in the `answer` field.