### PR TITLE
added "modelOverrides" field to ask_question() call

### DIFF
--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -315,7 +315,7 @@ class Chat:
         result = self.gql_client.submit(op, create_chat_thread_args)
         return result.create_chat_thread
 
-    def queue_chat_question(self, question: str, thread_id: str, skip_cache: bool = False) -> MaxChatEntry:
+    def queue_chat_question(self, question: str, thread_id: str, skip_cache: bool = False, model_overrides: dict = None) -> MaxChatEntry:
         """
         This queues up a question for processing. Unlike ask_question, this will not wait for the processing to
         complete. It will immediately return a shell entry with an id you can use to query for the results.
@@ -324,10 +324,17 @@ class Chat:
         :param skip_cache: Set to true to force a fresh run of the question, ignoring any existing skill result caches.
         :return:
         """
+
+        override_list = []
+        if model_overrides:
+            for key in model_overrides:
+                override_list.append({"modelType": key, "modelName": model_overrides[key]})
+
         queue_chat_question_args = {
             'question': question,
             'skipCache': skip_cache,
-            'threadId': thread_id
+            'threadId': thread_id,
+            'modelOverrides': override_list if override_list else None
         }
 
         op = Operations.mutation.queue_chat_question

--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -158,8 +158,9 @@ class Chat:
         :param question: The natural language question to ask the engine.
         :param thread_id: (optional) ID of the thread/conversation to run the question on. The question and answer will
          be added to the bottom of the thread.
-        :param skip_report_cache: Should the report cache be skipped for this question?
+        :param skip_report_cache: Should the report cache åbe skipped for this question?
         :param dry_run_type: If provided, run a dry run at the specified level: 'SKIP_SKILL_EXEC', 'SKIP_SKILL_NLG'
+        :param model_overrides: If provided, a dictionary of model types to model names to override the LLM model used. Model type options are 'CHAT', 'EMBEDDINGS', 'NARRATIVE'
         :return: the ChatEntry response object associate with the answer from the pipeline
         """
         override_list = []
@@ -322,6 +323,7 @@ class Chat:
         :param question: the text of the user's question
         :param thread_id: id of the thread the question is being sent to.
         :param skip_cache: Set to true to force a fresh run of the question, ignoring any existing skill result caches.
+        :param model_overrides: If provided, a dictionary of model types to model names to override the LLM model used. Model type options are 'CHAT', 'EMBEDDINGS', 'NARRATIVE'
         :return:
         """
 

--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -12,7 +12,7 @@ from answer_rocket.graphql.client import GraphQlClient
 from answer_rocket.graphql.schema import (LLMApiConfig, AzureOpenaiCompletionLLMApiConfig,
                                           AzureOpenaiEmbeddingLLMApiConfig, OpenaiCompletionLLMApiConfig,
                                           OpenaiEmbeddingLLMApiConfig, UUID, Int, DateTime, ChatDryRunType,
-                                          MaxChatEntry, MaxChatThread, SharedThread)
+                                          MaxChatEntry, MaxChatThread, SharedThread, ModelOverride)
 from answer_rocket.graphql.sdk_operations import Operations
 
 
@@ -150,7 +150,7 @@ class Chat:
 
         return False, str(last_error)
 
-    def ask_question(self, copilot_id: str, question: str, thread_id: str = None, skip_report_cache: bool = False, dry_run_type: str = None):
+    def ask_question(self, copilot_id: str, question: str, thread_id: str = None, skip_report_cache: bool = False, dry_run_type: str = None, model_overrides: dict = None):
         """
         Calls the Max chat pipeline to answer a natural language question and receive analysis and insights
         in response.
@@ -162,12 +162,18 @@ class Chat:
         :param dry_run_type: If provided, run a dry run at the specified level: 'SKIP_SKILL_EXEC', 'SKIP_SKILL_NLG'
         :return: the ChatEntry response object associate with the answer from the pipeline
         """
+        override_list = []
+        if model_overrides:
+            for key in model_overrides:
+                override_list.append({"modelType": key, "modelName": model_overrides[key]})
+
         ask_question_query_args = {
             'copilotId': UUID(copilot_id),
             'question': question,
             'threadId': UUID(thread_id) if thread_id else None,
             'skipReportCache': skip_report_cache,
-            'dryRunType': ChatDryRunType(dry_run_type) if dry_run_type else None
+            'dryRunType': ChatDryRunType(dry_run_type) if dry_run_type else None,
+            'modelOverrides': override_list if override_list else None
         }
 
         op = Operations.mutation.ask_chat_question

--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -158,7 +158,7 @@ class Chat:
         :param question: The natural language question to ask the engine.
         :param thread_id: (optional) ID of the thread/conversation to run the question on. The question and answer will
          be added to the bottom of the thread.
-        :param skip_report_cache: Should the report cache åbe skipped for this question?
+        :param skip_report_cache: Should the report cache be skipped for this question?
         :param dry_run_type: If provided, run a dry run at the specified level: 'SKIP_SKILL_EXEC', 'SKIP_SKILL_NLG'
         :param model_overrides: If provided, a dictionary of model types to model names to override the LLM model used. Model type options are 'CHAT', 'EMBEDDINGS', 'NARRATIVE'
         :return: the ChatEntry response object associate with the answer from the pipeline

--- a/answer_rocket/graphql/operations/chat.gql
+++ b/answer_rocket/graphql/operations/chat.gql
@@ -1,103 +1,100 @@
-
 mutation AskChatQuestion(
-    $copilotId: UUID!
-    $question: String!
-    $threadId: UUID
-    $skipReportCache: Boolean
-    $dryRunType: ChatDryRunType
+  $copilotId: UUID!
+  $question: String!
+  $threadId: UUID
+  $skipReportCache: Boolean
+  $dryRunType: ChatDryRunType
+  $modelOverrides: [ModelOverride]
 ) {
-    askChatQuestion(
-        copilotId: $copilotId,
-        question: $question,
-        threadId: $threadId
-        skipReportCache: $skipReportCache
-        dryRunType: $dryRunType
-    ) {
-        id
-        threadId
-        answer {
-            ...ChatResultFragment
-        }
+  askChatQuestion(
+    copilotId: $copilotId
+    question: $question
+    threadId: $threadId
+    skipReportCache: $skipReportCache
+    dryRunType: $dryRunType
+    modelOverrides: $modelOverrides
+  ) {
+    id
+    threadId
+    answer {
+      ...ChatResultFragment
     }
+  }
 }
 
 mutation QueueChatQuestion(
-    $threadId: UUID!
-    $question: String!
-    $skipCache: Boolean
+  $threadId: UUID!
+  $question: String!
+  $skipCache: Boolean
 ) {
-    queueChatQuestion(
-        threadId: $threadId,
-        question: $question,
-        skipCache: $skipCache,
-    ) {
-        threadId
-        id
-    }
+  queueChatQuestion(
+    threadId: $threadId
+    question: $question
+    skipCache: $skipCache
+  ) {
+    threadId
+    id
+  }
 }
 
 fragment ChatResultFragment on MaxChatResult {
-    answerId
-    answeredAt
-    copilotSkillId
-    hasFinished
-    error
-    isNewThread
-    message
-    reportResults {
-        title
-        reportName
-        parameters {
-            key
-            values
-            label
-        }
-        customPayload
+  answerId
+  answeredAt
+  copilotSkillId
+  hasFinished
+  error
+  isNewThread
+  message
+  reportResults {
+    title
+    reportName
+    parameters {
+      key
+      values
+      label
     }
+    customPayload
+  }
+  threadId
+  userId
+}
+
+mutation CancelChatQuestion($entryId: UUID!) {
+  cancelChatQuestion(entryId: $entryId) {
     threadId
-    userId
+    id
+  }
 }
 
-mutation CancelChatQuestion(
-    $entryId: UUID!
-) {
-    cancelChatQuestion(entryId: $entryId) {
-        threadId
-        id
+query ChatEntry($id: UUID!) {
+  chatEntry(id: $id) {
+    id
+    threadId
+    answer {
+      ...ChatResultFragment
     }
-}
-
-query ChatEntry(
-    $id: UUID!
-) {
-    chatEntry(id: $id) {
-        id
-        threadId
-        answer {
-            ...ChatResultFragment
-        }
-    }
+  }
 }
 
 query ChatThread($id: UUID!) {
-    chatThread(id: $id) {
-        id
-        entryCount
-        title
-        copilotId
-        entries {
-            id
-            threadId
-            answer {
-                ...ChatResultFragment
-            }
-        }
+  chatThread(id: $id) {
+    id
+    entryCount
+    title
+    copilotId
+    entries {
+      id
+      threadId
+      answer {
+        ...ChatResultFragment
+      }
     }
+  }
 }
 
 mutation CreateChatThread($copilotId: UUID!) {
-    createChatThread(copilotId: $copilotId) {
-        id
-        copilotId
-    }
+  createChatThread(copilotId: $copilotId) {
+    id
+    copilotId
+  }
 }

--- a/answer_rocket/graphql/operations/chat.gql
+++ b/answer_rocket/graphql/operations/chat.gql
@@ -26,11 +26,13 @@ mutation QueueChatQuestion(
   $threadId: UUID!
   $question: String!
   $skipCache: Boolean
+  $modelOverrides: [ModelOverride]
 ) {
   queueChatQuestion(
     threadId: $threadId
     question: $question
     skipCache: $skipCache
+    modelOverrides: $modelOverrides
   ) {
     threadId
     id

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -605,6 +605,7 @@ class Mutation(sgqlc.types.Type):
         ('thread_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='threadId', default=None)),
         ('question', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='question', default=None)),
         ('skip_cache', sgqlc.types.Arg(Boolean, graphql_name='skipCache', default=None)),
+        ('model_overrides', sgqlc.types.Arg(sgqlc.types.list_of(ModelOverride), graphql_name='modelOverrides', default=None)),
 ))
     )
     cancel_chat_question = sgqlc.types.Field(MaxChatEntry, graphql_name='cancelChatQuestion', args=sgqlc.types.ArgDict((

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -36,6 +36,11 @@ class MetricType(sgqlc.types.Enum):
     __choices__ = ('BASIC', 'RATIO', 'SHARE')
 
 
+class ModelTypes(sgqlc.types.Enum):
+    __schema__ = schema
+    __choices__ = ('CHAT', 'EMBEDDINGS', 'NARRATIVE')
+
+
 class SimplifiedDataType(sgqlc.types.Enum):
     __schema__ = schema
     __choices__ = ('BOOLEAN', 'DATE', 'NUMBER', 'STRING')
@@ -58,6 +63,13 @@ class MaxCopilotQuestionInput(sgqlc.types.Input):
     nl = sgqlc.types.Field(String, graphql_name='nl')
     hint = sgqlc.types.Field(String, graphql_name='hint')
     parameters = sgqlc.types.Field(JSON, graphql_name='parameters')
+
+
+class ModelOverride(sgqlc.types.Input):
+    __schema__ = schema
+    __field_names__ = ('model_type', 'model_name')
+    model_type = sgqlc.types.Field(sgqlc.types.non_null(ModelTypes), graphql_name='modelType')
+    model_name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='modelName')
 
 
 
@@ -581,6 +593,7 @@ class Mutation(sgqlc.types.Type):
         ('thread_id', sgqlc.types.Arg(UUID, graphql_name='threadId', default=None)),
         ('skip_report_cache', sgqlc.types.Arg(Boolean, graphql_name='skipReportCache', default=None)),
         ('dry_run_type', sgqlc.types.Arg(ChatDryRunType, graphql_name='dryRunType', default=None)),
+        ('model_overrides', sgqlc.types.Arg(sgqlc.types.list_of(ModelOverride), graphql_name='modelOverrides', default=None)),
 ))
     )
     evaluate_chat_question = sgqlc.types.Field(sgqlc.types.non_null(EvaluateChatQuestionResponse), graphql_name='evaluateChatQuestion', args=sgqlc.types.ArgDict((

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -45,8 +45,8 @@ def mutation_ask_chat_question():
 
 
 def mutation_queue_chat_question():
-    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='QueueChatQuestion', variables=dict(threadId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), question=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), skipCache=sgqlc.types.Arg(_schema.Boolean)))
-    _op_queue_chat_question = _op.queue_chat_question(thread_id=sgqlc.types.Variable('threadId'), question=sgqlc.types.Variable('question'), skip_cache=sgqlc.types.Variable('skipCache'))
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='QueueChatQuestion', variables=dict(threadId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), question=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), skipCache=sgqlc.types.Arg(_schema.Boolean), modelOverrides=sgqlc.types.Arg(sgqlc.types.list_of(_schema.ModelOverride))))
+    _op_queue_chat_question = _op.queue_chat_question(thread_id=sgqlc.types.Variable('threadId'), question=sgqlc.types.Variable('question'), skip_cache=sgqlc.types.Variable('skipCache'), model_overrides=sgqlc.types.Variable('modelOverrides'))
     _op_queue_chat_question.thread_id()
     _op_queue_chat_question.id()
     return _op

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -35,8 +35,8 @@ class Fragment:
 
 
 def mutation_ask_chat_question():
-    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='AskChatQuestion', variables=dict(copilotId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), question=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), threadId=sgqlc.types.Arg(_schema.UUID), skipReportCache=sgqlc.types.Arg(_schema.Boolean), dryRunType=sgqlc.types.Arg(_schema.ChatDryRunType)))
-    _op_ask_chat_question = _op.ask_chat_question(copilot_id=sgqlc.types.Variable('copilotId'), question=sgqlc.types.Variable('question'), thread_id=sgqlc.types.Variable('threadId'), skip_report_cache=sgqlc.types.Variable('skipReportCache'), dry_run_type=sgqlc.types.Variable('dryRunType'))
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='AskChatQuestion', variables=dict(copilotId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), question=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), threadId=sgqlc.types.Arg(_schema.UUID), skipReportCache=sgqlc.types.Arg(_schema.Boolean), dryRunType=sgqlc.types.Arg(_schema.ChatDryRunType), modelOverrides=sgqlc.types.Arg(sgqlc.types.list_of(_schema.ModelOverride))))
+    _op_ask_chat_question = _op.ask_chat_question(copilot_id=sgqlc.types.Variable('copilotId'), question=sgqlc.types.Variable('question'), thread_id=sgqlc.types.Variable('threadId'), skip_report_cache=sgqlc.types.Variable('skipReportCache'), dry_run_type=sgqlc.types.Variable('dryRunType'), model_overrides=sgqlc.types.Variable('modelOverrides'))
     _op_ask_chat_question.id()
     _op_ask_chat_question.thread_id()
     _op_ask_chat_question_answer = _op_ask_chat_question.answer()


### PR DESCRIPTION
Users can now specify which model should be used in an `ask_question()` call by providing a `modelOverrides` dict.