### PR TITLE
added 'indicated_skills' field to ask_question and queue_chat_question calls

### DIFF
--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -150,7 +150,7 @@ class Chat:
 
         return False, str(last_error)
 
-    def ask_question(self, copilot_id: str, question: str, thread_id: str = None, skip_report_cache: bool = False, dry_run_type: str = None, model_overrides: dict = None):
+    def ask_question(self, copilot_id: str, question: str, thread_id: str = None, skip_report_cache: bool = False, dry_run_type: str = None, model_overrides: dict = None, indicated_skills: list[str] = None):
         """
         Calls the Max chat pipeline to answer a natural language question and receive analysis and insights
         in response.
@@ -161,6 +161,7 @@ class Chat:
         :param skip_report_cache: Should the report cache be skipped for this question?
         :param dry_run_type: If provided, run a dry run at the specified level: 'SKIP_SKILL_EXEC', 'SKIP_SKILL_NLG'
         :param model_overrides: If provided, a dictionary of model types to model names to override the LLM model used. Model type options are 'CHAT', 'EMBEDDINGS', 'NARRATIVE'
+        :param indicated_skills: If provided, a list of skill names that the copilot will be limited to choosing from. If only 1 skill is provided the copilot will be guaranteed to execute that skill.
         :return: the ChatEntry response object associate with the answer from the pipeline
         """
         override_list = []
@@ -174,7 +175,8 @@ class Chat:
             'threadId': UUID(thread_id) if thread_id else None,
             'skipReportCache': skip_report_cache,
             'dryRunType': ChatDryRunType(dry_run_type) if dry_run_type else None,
-            'modelOverrides': override_list if override_list else None
+            'modelOverrides': override_list if override_list else None,
+            'indicatedSkills': indicated_skills
         }
 
         op = Operations.mutation.ask_chat_question
@@ -316,7 +318,7 @@ class Chat:
         result = self.gql_client.submit(op, create_chat_thread_args)
         return result.create_chat_thread
 
-    def queue_chat_question(self, question: str, thread_id: str, skip_cache: bool = False, model_overrides: dict = None) -> MaxChatEntry:
+    def queue_chat_question(self, question: str, thread_id: str, skip_cache: bool = False, model_overrides: dict = None, indicated_skills: list[str] = None) -> MaxChatEntry:
         """
         This queues up a question for processing. Unlike ask_question, this will not wait for the processing to
         complete. It will immediately return a shell entry with an id you can use to query for the results.
@@ -324,6 +326,7 @@ class Chat:
         :param thread_id: id of the thread the question is being sent to.
         :param skip_cache: Set to true to force a fresh run of the question, ignoring any existing skill result caches.
         :param model_overrides: If provided, a dictionary of model types to model names to override the LLM model used. Model type options are 'CHAT', 'EMBEDDINGS', 'NARRATIVE'
+        :param indicated_skills: If provided, a list of skill names that the copilot will be limited to choosing from. If only 1 skill is provided the copilot will be guaranteed to execute that skill.
         :return:
         """
 
@@ -336,7 +339,8 @@ class Chat:
             'question': question,
             'skipCache': skip_cache,
             'threadId': thread_id,
-            'modelOverrides': override_list if override_list else None
+            'modelOverrides': override_list if override_list else None,
+            'indicatedSkills': indicated_skills
         }
 
         op = Operations.mutation.queue_chat_question

--- a/answer_rocket/graphql/operations/chat.gql
+++ b/answer_rocket/graphql/operations/chat.gql
@@ -5,6 +5,7 @@ mutation AskChatQuestion(
   $skipReportCache: Boolean
   $dryRunType: ChatDryRunType
   $modelOverrides: [ModelOverride]
+  $indicatedSkills: [String]
 ) {
   askChatQuestion(
     copilotId: $copilotId
@@ -13,6 +14,7 @@ mutation AskChatQuestion(
     skipReportCache: $skipReportCache
     dryRunType: $dryRunType
     modelOverrides: $modelOverrides
+    indicatedSkills: $indicatedSkills
   ) {
     id
     threadId
@@ -27,12 +29,14 @@ mutation QueueChatQuestion(
   $question: String!
   $skipCache: Boolean
   $modelOverrides: [ModelOverride]
+  $indicatedSkills: [String]
 ) {
   queueChatQuestion(
     threadId: $threadId
     question: $question
     skipCache: $skipCache
     modelOverrides: $modelOverrides
+    indicatedSkills: $indicatedSkills
   ) {
     threadId
     id

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -594,6 +594,7 @@ class Mutation(sgqlc.types.Type):
         ('skip_report_cache', sgqlc.types.Arg(Boolean, graphql_name='skipReportCache', default=None)),
         ('dry_run_type', sgqlc.types.Arg(ChatDryRunType, graphql_name='dryRunType', default=None)),
         ('model_overrides', sgqlc.types.Arg(sgqlc.types.list_of(ModelOverride), graphql_name='modelOverrides', default=None)),
+        ('indicated_skills', sgqlc.types.Arg(sgqlc.types.list_of(String), graphql_name='indicatedSkills', default=None)),
 ))
     )
     evaluate_chat_question = sgqlc.types.Field(sgqlc.types.non_null(EvaluateChatQuestionResponse), graphql_name='evaluateChatQuestion', args=sgqlc.types.ArgDict((
@@ -606,6 +607,7 @@ class Mutation(sgqlc.types.Type):
         ('question', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='question', default=None)),
         ('skip_cache', sgqlc.types.Arg(Boolean, graphql_name='skipCache', default=None)),
         ('model_overrides', sgqlc.types.Arg(sgqlc.types.list_of(ModelOverride), graphql_name='modelOverrides', default=None)),
+        ('indicated_skills', sgqlc.types.Arg(sgqlc.types.list_of(String), graphql_name='indicatedSkills', default=None)),
 ))
     )
     cancel_chat_question = sgqlc.types.Field(MaxChatEntry, graphql_name='cancelChatQuestion', args=sgqlc.types.ArgDict((

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -35,8 +35,8 @@ class Fragment:
 
 
 def mutation_ask_chat_question():
-    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='AskChatQuestion', variables=dict(copilotId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), question=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), threadId=sgqlc.types.Arg(_schema.UUID), skipReportCache=sgqlc.types.Arg(_schema.Boolean), dryRunType=sgqlc.types.Arg(_schema.ChatDryRunType), modelOverrides=sgqlc.types.Arg(sgqlc.types.list_of(_schema.ModelOverride))))
-    _op_ask_chat_question = _op.ask_chat_question(copilot_id=sgqlc.types.Variable('copilotId'), question=sgqlc.types.Variable('question'), thread_id=sgqlc.types.Variable('threadId'), skip_report_cache=sgqlc.types.Variable('skipReportCache'), dry_run_type=sgqlc.types.Variable('dryRunType'), model_overrides=sgqlc.types.Variable('modelOverrides'))
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='AskChatQuestion', variables=dict(copilotId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), question=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), threadId=sgqlc.types.Arg(_schema.UUID), skipReportCache=sgqlc.types.Arg(_schema.Boolean), dryRunType=sgqlc.types.Arg(_schema.ChatDryRunType), modelOverrides=sgqlc.types.Arg(sgqlc.types.list_of(_schema.ModelOverride)), indicatedSkills=sgqlc.types.Arg(sgqlc.types.list_of(_schema.String))))
+    _op_ask_chat_question = _op.ask_chat_question(copilot_id=sgqlc.types.Variable('copilotId'), question=sgqlc.types.Variable('question'), thread_id=sgqlc.types.Variable('threadId'), skip_report_cache=sgqlc.types.Variable('skipReportCache'), dry_run_type=sgqlc.types.Variable('dryRunType'), model_overrides=sgqlc.types.Variable('modelOverrides'), indicated_skills=sgqlc.types.Variable('indicatedSkills'))
     _op_ask_chat_question.id()
     _op_ask_chat_question.thread_id()
     _op_ask_chat_question_answer = _op_ask_chat_question.answer()
@@ -45,8 +45,8 @@ def mutation_ask_chat_question():
 
 
 def mutation_queue_chat_question():
-    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='QueueChatQuestion', variables=dict(threadId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), question=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), skipCache=sgqlc.types.Arg(_schema.Boolean), modelOverrides=sgqlc.types.Arg(sgqlc.types.list_of(_schema.ModelOverride))))
-    _op_queue_chat_question = _op.queue_chat_question(thread_id=sgqlc.types.Variable('threadId'), question=sgqlc.types.Variable('question'), skip_cache=sgqlc.types.Variable('skipCache'), model_overrides=sgqlc.types.Variable('modelOverrides'))
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='QueueChatQuestion', variables=dict(threadId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), question=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), skipCache=sgqlc.types.Arg(_schema.Boolean), modelOverrides=sgqlc.types.Arg(sgqlc.types.list_of(_schema.ModelOverride)), indicatedSkills=sgqlc.types.Arg(sgqlc.types.list_of(_schema.String))))
+    _op_queue_chat_question = _op.queue_chat_question(thread_id=sgqlc.types.Variable('threadId'), question=sgqlc.types.Variable('question'), skip_cache=sgqlc.types.Variable('skipCache'), model_overrides=sgqlc.types.Variable('modelOverrides'), indicated_skills=sgqlc.types.Variable('indicatedSkills'))
     _op_queue_chat_question.thread_id()
     _op_queue_chat_question.id()
     return _op


### PR DESCRIPTION
a list of skill names `indicated_skills` can be passed to `ask_question()` and `queue_chat_question()` . The copilot will be limited to this list of skills when answering the question. If only 1 skill is provided in the list, the copilot will be guaranteed to execute that skill when answering.