### PR TITLE
Bugfix: Issue fetching skills with dynamic components.

### DIFF
--- a/answer_rocket/__init__.py
+++ b/answer_rocket/__init__.py
@@ -3,7 +3,7 @@ __all__ = [
     'AnswerRocketClient'
 ]
 
-__version__ = "0.2.21"
+__version__ = "0.2.22"
 
 from answer_rocket.client import AnswerRocketClient
 from answer_rocket.error import AnswerRocketClientError

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -328,12 +328,11 @@ class MaxChatThread(sgqlc.types.Type):
 
 class MaxChatUser(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('id', 'given_name', 'family_name', 'email_address', 'groups')
+    __field_names__ = ('id', 'given_name', 'family_name', 'email_address')
     id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='id')
     given_name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='givenName')
     family_name = sgqlc.types.Field(String, graphql_name='familyName')
     email_address = sgqlc.types.Field(String, graphql_name='emailAddress')
-    groups = sgqlc.types.Field(sgqlc.types.list_of(String), graphql_name='groups')
 
 
 class MaxColumn(sgqlc.types.Type):
@@ -413,7 +412,7 @@ class MaxCopilotSkillNode(sgqlc.types.Type):
     __schema__ = schema
     __field_names__ = ('copilot_skill_node_id', 'skill_component_id', 'name', 'description', 'user_data', 'node_connections')
     copilot_skill_node_id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='copilotSkillNodeId')
-    skill_component_id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='skillComponentId')
+    skill_component_id = sgqlc.types.Field(UUID, graphql_name='skillComponentId')
     name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='name')
     description = sgqlc.types.Field(String, graphql_name='description')
     user_data = sgqlc.types.Field(JSON, graphql_name='userData')
@@ -679,7 +678,7 @@ class Mutation(sgqlc.types.Type):
 
 class Query(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user')
+    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry')
     ping = sgqlc.types.Field(String, graphql_name='ping')
     current_user = sgqlc.types.Field(MaxUser, graphql_name='currentUser')
     get_copilot_skill_artifact_by_path = sgqlc.types.Field(CopilotSkillArtifact, graphql_name='getCopilotSkillArtifactByPath', args=sgqlc.types.ArgDict((
@@ -769,10 +768,6 @@ class Query(sgqlc.types.Type):
 ))
     )
     chat_entry = sgqlc.types.Field(MaxChatEntry, graphql_name='chatEntry', args=sgqlc.types.ArgDict((
-        ('id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='id', default=None)),
-))
-    )
-    user = sgqlc.types.Field(MaxChatUser, graphql_name='user', args=sgqlc.types.ArgDict((
         ('id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='id', default=None)),
 ))
     )


### PR DESCRIPTION
Updating the schema so that skill_component_id is non-null, which is the case for dynamic components. Previously we would error out in get_copilot_skill when fetching a copilot skill that contained a dynamic component.

Corresponding commit to change the schema: https://bitbucket.org/aglabs/nfl/commits/b032e15002de456801faa94aa5f68a967e8e39a2 