### PR TITLE
all_chat_entries query now receives report_results

### DIFF
--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -12,7 +12,7 @@ from answer_rocket.graphql.client import GraphQlClient
 from answer_rocket.graphql.schema import (LLMApiConfig, AzureOpenaiCompletionLLMApiConfig,
                                           AzureOpenaiEmbeddingLLMApiConfig, OpenaiCompletionLLMApiConfig,
                                           OpenaiEmbeddingLLMApiConfig, UUID, Int, DateTime, ChatDryRunType,
-                                          MaxChatEntry, MaxChatThread, SharedThread, JSON, MaxChatUser)
+                                          MaxChatEntry, MaxChatThread, SharedThread, MaxChatUser)
 from answer_rocket.graphql.sdk_operations import Operations
 
 logger = logging.getLogger(__name__)
@@ -409,7 +409,7 @@ class Chat:
 
         return result.user
 
-    def get_all_chat_entries(self, offset=0, limit=100, filters=None):
+    def get_all_chat_entries(self, offset=0, limit=100, filters=None) -> list[MaxChatEntry]:
         """
         Fetches all chat entries with optional filters.
         :param offset: the offset to start fetching entries from. Default is 0.
@@ -507,17 +507,8 @@ class Chat:
             'limit': limit,
             'filters': filters,
         }
-        get_all_chat_entries_query_vars = {
-            'offset': Arg(Int),
-            'limit': Arg(Int),
-            'filters': Arg(JSON),
-        }
-        operation = self.gql_client.query(variables=get_all_chat_entries_query_vars)
-        get_all_chat_entries_query = operation.all_chat_entries(
-            offset=Variable('offset'),
-            limit=Variable('limit'),
-            filters=Variable('filters'),
-        )
+
+        operation = Operations.query.all_chat_entries
 
         result = self.gql_client.submit(operation, get_all_chat_entries_query_args)
 

--- a/answer_rocket/graphql/operations/chat.gql
+++ b/answer_rocket/graphql/operations/chat.gql
@@ -107,6 +107,22 @@ query ChatThread($id: UUID!) {
   }
 }
 
+query AllChatEntries($offset: Int, $limit: Int, $filters: JSON) {
+  allChatEntries(offset: $offset, limit: $limit, filters: $filters) {
+    id
+    threadId
+    question {
+        askedAt
+        nl
+    }
+    answer {
+      ...ChatResultFragment
+    }
+    feedback
+    user
+  }
+}
+
 mutation CreateChatThread($copilotId: UUID!) {
   createChatThread(copilotId: $copilotId) {
     id

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -356,7 +356,8 @@ class MaxColumn(sgqlc.types.Type):
 
 class MaxContentBlock(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('title', 'payload', 'type')
+    __field_names__ = ('id', 'title', 'payload', 'type')
+    id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='id')
     title = sgqlc.types.Field(String, graphql_name='title')
     payload = sgqlc.types.Field(String, graphql_name='payload')
     type = sgqlc.types.Field(String, graphql_name='type')

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -112,6 +112,21 @@ def query_chat_thread():
     return _op
 
 
+def query_all_chat_entries():
+    _op = sgqlc.operation.Operation(_schema_root.query_type, name='AllChatEntries', variables=dict(offset=sgqlc.types.Arg(_schema.Int), limit=sgqlc.types.Arg(_schema.Int), filters=sgqlc.types.Arg(_schema.JSON)))
+    _op_all_chat_entries = _op.all_chat_entries(offset=sgqlc.types.Variable('offset'), limit=sgqlc.types.Variable('limit'), filters=sgqlc.types.Variable('filters'))
+    _op_all_chat_entries.id()
+    _op_all_chat_entries.thread_id()
+    _op_all_chat_entries_question = _op_all_chat_entries.question()
+    _op_all_chat_entries_question.asked_at()
+    _op_all_chat_entries_question.nl()
+    _op_all_chat_entries_answer = _op_all_chat_entries.answer()
+    _op_all_chat_entries_answer.__fragment__(fragment_chat_result_fragment())
+    _op_all_chat_entries.feedback()
+    _op_all_chat_entries.user()
+    return _op
+
+
 def query_get_max_llm_prompt():
     _op = sgqlc.operation.Operation(_schema_root.query_type, name='GetMaxLlmPrompt', variables=dict(llmPromptId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), templateVariables=sgqlc.types.Arg(_schema.JSON), kShotMatch=sgqlc.types.Arg(_schema.String)))
     _op_get_max_llm_prompt = _op.get_max_llm_prompt(llm_prompt_id=sgqlc.types.Variable('llmPromptId'), template_variables=sgqlc.types.Variable('templateVariables'), k_shot_match=sgqlc.types.Variable('kShotMatch'))
@@ -153,6 +168,7 @@ def query_get_copilot_skill():
 
 
 class Query:
+    all_chat_entries = query_all_chat_entries()
     chat_entry = query_chat_entry()
     chat_thread = query_chat_thread()
     get_copilot_skill = query_get_copilot_skill()


### PR DESCRIPTION
@PGAnswerRocket I've changed the all_chat_entries query to grab the fields we want... this way it will include report_results like the other chat entry queries do.

Let me know if I missed any important GQL fields in my query. I tested this locally and got back good results.