### PR TITLE
add support for a mutation to update the chat loading message

### DIFF
--- a/answer_rocket/client_config.py
+++ b/answer_rocket/client_config.py
@@ -11,7 +11,8 @@ class ClientConfig:
         token: an auth token
         tenant: the tenant id, provided automatically
         is_live_run: set when the client is used in a skill run (as opposed to someone running it locally)
-        answer_id: the answer_id that any answer-updating calls will use
+        answer_id: the skill run answer_id that any answer-updating calls will use
+        entry_answer_id: the answer_id for the chat entry being created
         user_id: provided automatically or implicitly via the auth token
         copilot_id: the copilot the skill is running within
         copilot_skill_id: the id of the skill in the environment
@@ -22,6 +23,7 @@ class ClientConfig:
     tenant: str | None
     is_live_run: bool
     answer_id: str | None
+    entry_answer_id: str | None
     user_id: str | None
     copilot_id: str | None
     copilot_skill_id: str | None
@@ -34,6 +36,7 @@ def load_client_config(url=None, token=None):
     tenant = os.getenv('AR_TENANT_ID')
     user_id = os.getenv('AR_USER_ID')
     answer_id = os.getenv('AR_ANSWER_ID')
+    entry_answer_id = os.getenv('AR_ENTRY_ANSWER_ID')
     copilot_id = os.getenv('AR_COPILOT_ID')
     copilot_skill_id = os.getenv('AR_COPILOT_SKILL_ID')
     is_live_run = os.getenv('AR_IS_RUNNING_ON_FLEET') or False
@@ -45,6 +48,7 @@ def load_client_config(url=None, token=None):
         user_id=user_id,
         is_live_run=is_live_run,
         answer_id=answer_id,
+        entry_answer_id=entry_answer_id,
         copilot_id=copilot_id,
         copilot_skill_id=copilot_skill_id,
         resource_base_path=resource_base_path

--- a/answer_rocket/graphql/operations/skill.gql
+++ b/answer_rocket/graphql/operations/skill.gql
@@ -1,0 +1,3 @@
+mutation UpdateLoadingMessage($answerId: UUID!, $message: String!) {
+    updateLoadingMessage(answerId: $answerId, message: $message)
+}

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -602,7 +602,7 @@ class MaxUser(sgqlc.types.Type):
 
 class Mutation(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('create_max_copilot_skill_chat_question', 'update_max_copilot_skill_chat_question', 'delete_max_copilot_skill_chat_question', 'create_max_copilot_question', 'update_max_copilot_question', 'delete_max_copilot_question', 'reload_dataset', 'update_dataset_date_range', 'update_chat_answer_payload', 'ask_chat_question', 'evaluate_chat_question', 'queue_chat_question', 'cancel_chat_question', 'create_chat_thread', 'add_feedback', 'share_thread')
+    __field_names__ = ('create_max_copilot_skill_chat_question', 'update_max_copilot_skill_chat_question', 'delete_max_copilot_skill_chat_question', 'create_max_copilot_question', 'update_max_copilot_question', 'delete_max_copilot_question', 'reload_dataset', 'update_dataset_date_range', 'update_chat_answer_payload', 'ask_chat_question', 'evaluate_chat_question', 'queue_chat_question', 'cancel_chat_question', 'create_chat_thread', 'add_feedback', 'share_thread', 'update_loading_message')
     create_max_copilot_skill_chat_question = sgqlc.types.Field(sgqlc.types.non_null(CreateMaxCopilotSkillChatQuestionResponse), graphql_name='createMaxCopilotSkillChatQuestion', args=sgqlc.types.ArgDict((
         ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
         ('copilot_skill_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotSkillId', default=None)),
@@ -700,6 +700,11 @@ class Mutation(sgqlc.types.Type):
     )
     share_thread = sgqlc.types.Field(sgqlc.types.non_null('SharedThread'), graphql_name='shareThread', args=sgqlc.types.ArgDict((
         ('original_thread_id', sgqlc.types.Arg(UUID, graphql_name='originalThreadId', default=None)),
+))
+    )
+    update_loading_message = sgqlc.types.Field(UUID, graphql_name='updateLoadingMessage', args=sgqlc.types.ArgDict((
+        ('answer_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='answerId', default=None)),
+        ('message', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='message', default=None)),
 ))
     )
 

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -77,12 +77,19 @@ def mutation_add_feedback():
     return _op
 
 
+def mutation_update_loading_message():
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='UpdateLoadingMessage', variables=dict(answerId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), message=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String))))
+    _op.update_loading_message(answer_id=sgqlc.types.Variable('answerId'), message=sgqlc.types.Variable('message'))
+    return _op
+
+
 class Mutation:
     add_feedback = mutation_add_feedback()
     ask_chat_question = mutation_ask_chat_question()
     cancel_chat_question = mutation_cancel_chat_question()
     create_chat_thread = mutation_create_chat_thread()
     queue_chat_question = mutation_queue_chat_question()
+    update_loading_message = mutation_update_loading_message()
 
 
 def query_chat_entry():

--- a/answer_rocket/skill.py
+++ b/answer_rocket/skill.py
@@ -2,6 +2,7 @@ from sgqlc.types import Arg, non_null, Variable
 from answer_rocket.client_config import ClientConfig
 from answer_rocket.graphql.client import GraphQlClient
 from answer_rocket.graphql.schema import JSON, String, UUID
+from answer_rocket.graphql.sdk_operations import Operations
 from answer_rocket.output import ChatReportOutput
 from answer_rocket.graphql.schema import UUID as GQL_UUID
 from answer_rocket.types import MaxResult, RESULT_EXCEPTION_CODE
@@ -77,3 +78,12 @@ class Skill:
             final_result.code = RESULT_EXCEPTION_CODE
 
         return final_result
+
+    def update_loading_message(self, message: str):
+        if self._config.entry_answer_id:
+            args = {
+                'answerId': self._config.entry_answer_id,
+                'message': message,
+            }
+            op = Operations.mutation.update_loading_message
+            self._gql_client.submit(op, args)


### PR DESCRIPTION
I added the chat entry's answer id to the client config since that is the data that needs updating for this to work (the existing answer_id is for the skill run), but the client method itself just takes the new message, so it should be easy to rework without changes that anyone using the library will have to care about.