### PR TITLE
add helpers for invoking chat/narrative completion of a configured LLM

### DIFF
--- a/answer_rocket/client.py
+++ b/answer_rocket/client.py
@@ -7,6 +7,7 @@ from answer_rocket.graphql.client import GraphQlClient
 from answer_rocket.chat import Chat
 from answer_rocket.output import OutputBuilder
 from answer_rocket.skill import Skill
+from answer_rocket.llm import Llm
 
 
 class AnswerRocketClient:
@@ -23,6 +24,7 @@ class AnswerRocketClient:
 		self.data = Data(self._client_config, self._gql_client)
 		self.output = OutputBuilder(self._client_config, self._gql_client)
 		self.skill = Skill(self._client_config, self._gql_client)
+		self.llm = Llm(self._client_config, self._gql_client)
 
 	def can_connect(self) -> bool:
 		"""

--- a/answer_rocket/graphql/operations/skill.gql
+++ b/answer_rocket/graphql/operations/skill.gql
@@ -1,3 +1,11 @@
 mutation UpdateLoadingMessage($answerId: UUID!, $message: String!) {
     updateLoadingMessage(answerId: $answerId, message: $message)
 }
+
+query ChatCompletion($messages: [LlmChatMessage!]!, $modelSelection: LlmModelSelection) {
+    chatCompletion(messages: $messages, modelSelection: $modelSelection)
+}
+
+query NarrativeCompletion($prompt: String!, $modelSelection: LlmModelSelection) {
+    narrativeCompletion(prompt: $prompt, modelSelection: $modelSelection)
+}

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -36,6 +36,10 @@ class JSON(sgqlc.types.Scalar):
     __schema__ = schema
 
 
+class LlmResponse(sgqlc.types.Scalar):
+    __schema__ = schema
+
+
 class MetricType(sgqlc.types.Enum):
     __schema__ = schema
     __choices__ = ('BASIC', 'RATIO', 'SHARE')
@@ -66,6 +70,20 @@ class FunctionCallMessageInput(sgqlc.types.Input):
     __field_names__ = ('name', 'arguments')
     name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='name')
     arguments = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='arguments')
+
+
+class LlmChatMessage(sgqlc.types.Input):
+    __schema__ = schema
+    __field_names__ = ('role', 'content')
+    role = sgqlc.types.Field(String, graphql_name='role')
+    content = sgqlc.types.Field(String, graphql_name='content')
+
+
+class LlmModelSelection(sgqlc.types.Input):
+    __schema__ = schema
+    __field_names__ = ('assistant_id', 'model_override')
+    assistant_id = sgqlc.types.Field(UUID, graphql_name='assistantId')
+    model_override = sgqlc.types.Field(String, graphql_name='modelOverride')
 
 
 class MaxCopilotQuestionInput(sgqlc.types.Input):
@@ -711,7 +729,7 @@ class Mutation(sgqlc.types.Type):
 
 class Query(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries')
+    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries', 'chat_completion', 'narrative_completion')
     ping = sgqlc.types.Field(String, graphql_name='ping')
     current_user = sgqlc.types.Field(MaxUser, graphql_name='currentUser')
     get_copilot_skill_artifact_by_path = sgqlc.types.Field(CopilotSkillArtifact, graphql_name='getCopilotSkillArtifactByPath', args=sgqlc.types.ArgDict((
@@ -812,6 +830,16 @@ class Query(sgqlc.types.Type):
         ('offset', sgqlc.types.Arg(Int, graphql_name='offset', default=None)),
         ('limit', sgqlc.types.Arg(Int, graphql_name='limit', default=None)),
         ('filters', sgqlc.types.Arg(JSON, graphql_name='filters', default=None)),
+))
+    )
+    chat_completion = sgqlc.types.Field(LlmResponse, graphql_name='chatCompletion', args=sgqlc.types.ArgDict((
+        ('messages', sgqlc.types.Arg(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(LlmChatMessage))), graphql_name='messages', default=None)),
+        ('model_selection', sgqlc.types.Arg(LlmModelSelection, graphql_name='modelSelection', default=None)),
+))
+    )
+    narrative_completion = sgqlc.types.Field(LlmResponse, graphql_name='narrativeCompletion', args=sgqlc.types.ArgDict((
+        ('prompt', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='prompt', default=None)),
+        ('model_selection', sgqlc.types.Arg(LlmModelSelection, graphql_name='modelSelection', default=None)),
 ))
     )
 

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -177,12 +177,26 @@ def query_get_copilot_skill():
     return _op
 
 
+def query_chat_completion():
+    _op = sgqlc.operation.Operation(_schema_root.query_type, name='ChatCompletion', variables=dict(messages=sgqlc.types.Arg(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(_schema.LlmChatMessage)))), modelSelection=sgqlc.types.Arg(_schema.LlmModelSelection)))
+    _op.chat_completion(messages=sgqlc.types.Variable('messages'), model_selection=sgqlc.types.Variable('modelSelection'))
+    return _op
+
+
+def query_narrative_completion():
+    _op = sgqlc.operation.Operation(_schema_root.query_type, name='NarrativeCompletion', variables=dict(prompt=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), modelSelection=sgqlc.types.Arg(_schema.LlmModelSelection)))
+    _op.narrative_completion(prompt=sgqlc.types.Variable('prompt'), model_selection=sgqlc.types.Variable('modelSelection'))
+    return _op
+
+
 class Query:
     all_chat_entries = query_all_chat_entries()
+    chat_completion = query_chat_completion()
     chat_entry = query_chat_entry()
     chat_thread = query_chat_thread()
     get_copilot_skill = query_get_copilot_skill()
     get_max_llm_prompt = query_get_max_llm_prompt()
+    narrative_completion = query_narrative_completion()
 
 
 class Operations:

--- a/answer_rocket/llm.py
+++ b/answer_rocket/llm.py
@@ -1,0 +1,58 @@
+from typing import TypedDict
+
+from answer_rocket.graphql.sdk_operations import Operations
+from answer_rocket.graphql.schema import LlmModelSelection
+
+
+class LlmChatMessage(TypedDict):
+    """
+    A chat message for passing to an LLM API
+    Attributes:
+        role: the role of the participant in this chat
+        content: the chat message
+    """
+    role: str
+    content: str
+
+
+class Llm:
+
+    def __init__(self, config, gql_client):
+        self.config = config
+        self.gql_client = gql_client
+
+    def chat_completion(self, messages: list[LlmChatMessage], model_override: str | None = None):
+        """
+        Call an LLM API's chat completion endpoint with the provided messages.
+        :param messages: a list of dictionaries describing each message in the chat, { "role": str, "content": str }
+        :param model_override: a model name or id to use instead of a configured default
+        :return: the raw response from the model api
+        """
+        op = Operations.query.chat_completion
+        args = {
+            'messages': messages,
+            'modelSelection': {
+                'assistantId': self.config.copilot_id,
+                'modelOverride': model_override
+            }
+        }
+        gql_response = self.gql_client.submit(op, args)
+        return gql_response.chat_completion
+
+    def narrative_completion(self, prompt: str, model_override: str | None = None):
+        """
+        Call an LLM API's completion endpoint with the provided prompt.
+        :param prompt: the prompt to send to the model
+        :param model_override: a model name or id to use instead of a configured default
+        :return: the raw response from the model api
+        """
+        op = Operations.query.narrative_completion
+        args = {
+            'prompt': prompt,
+            'modelSelection': {
+                'assistantId': self.config.copilot_id,
+                'modelOverride': model_override
+            }
+        }
+        gql_response = self.gql_client.submit(op, args)
+        return gql_response.narrative_completion


### PR DESCRIPTION
This adds two helpers for invoking narrative/chat completion for a configured llm.

`chat_completion` accepts the typical `{ role: str, content: str }` payload
`narrative_completion` accepts a prompt

Both can be manually overridden with a model id or name to use instead of the default configured on the in-context copilot/assistant or the default for the environment.

The response in both cases is just the raw model response. I am not sure if these are consistent enough to put types on yet, so maybe we can make it consistent and then put a proper type to it, but in the meantime it is just a scalar.