### PR TITLE
Max sql gen and SQL AI

### DIFF
--- a/answer_rocket/client.py
+++ b/answer_rocket/client.py
@@ -12,12 +12,12 @@ from answer_rocket.llm import Llm
 
 class AnswerRocketClient:
 
-	def __init__(self, url: Optional[str] = None, token: Optional[str] = None):
+	def __init__(self, url: Optional[str] = None, token: Optional[str] = None, tenant: str = None):
 		"""
 		url: the url of your AnswerRocket instance. You may also set the AR_URL env var instead.
 		token: a valid sdk token. You may also set the AR_TOKEN env var instead to keep it out of your code.
 		"""
-		self._client_config = load_client_config(url, token)
+		self._client_config = load_client_config(url, token, tenant)
 		self._gql_client: GraphQlClient = GraphQlClient(self._client_config)
 		self.config = Config(self._client_config, self._gql_client)
 		self.chat = Chat(self._gql_client)

--- a/answer_rocket/client_config.py
+++ b/answer_rocket/client_config.py
@@ -30,10 +30,10 @@ class ClientConfig:
     resource_base_path: str | None
 
 
-def load_client_config(url=None, token=None):
+def load_client_config(url=None, token=None, tenant: str = None):
     token = token or os.getenv('AR_TOKEN')
     url = url or os.getenv('AR_URL')
-    tenant = os.getenv('AR_TENANT_ID')
+    effective_tenant = tenant if tenant else os.getenv('AR_TENANT_ID')
     user_id = os.getenv('AR_USER_ID')
     answer_id = os.getenv('AR_ANSWER_ID')
     entry_answer_id = os.getenv('AR_ENTRY_ANSWER_ID')
@@ -44,7 +44,7 @@ def load_client_config(url=None, token=None):
     return ClientConfig(
         url=url,
         token=token,
-        tenant=tenant,
+        tenant=effective_tenant,
         user_id=user_id,
         is_live_run=is_live_run,
         answer_id=answer_id,

--- a/answer_rocket/data.py
+++ b/answer_rocket/data.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Optional, List, Dict
 from uuid import UUID
 
@@ -13,16 +14,17 @@ from answer_rocket.graphql.schema import UUID as GQL_UUID, MaxMetricAttribute, M
     MaxMutationResponse, DateTime, RunMaxSqlGenResponse, JSON, RunSqlAiResponse
 from answer_rocket.types import MaxResult, RESULT_EXCEPTION_CODE
 
-
+@dataclass
 class ExecuteSqlQueryResult(MaxResult):
     df = None
+    data = None
 
-
+@dataclass
 class ExecuteRqlQueryResult(MaxResult):
     df = None
     rql_script_response = None
 
-
+@dataclass
 class DomainObjectResult(MaxResult):
     domain_object = None
 
@@ -95,6 +97,7 @@ class Data:
                 df = pd.DataFrame(rows, columns=columns)
 
                 execute_sql_query_result.df = df
+                execute_sql_query_result.data = data
 
             return execute_sql_query_result
         except Exception as e:

--- a/answer_rocket/data.py
+++ b/answer_rocket/data.py
@@ -1,4 +1,3 @@
-import os
 from typing import Optional, List, Dict
 from uuid import UUID
 
@@ -8,10 +7,10 @@ from sgqlc.types import Variable, Arg, non_null, String, Int, list_of
 
 from answer_rocket.client_config import ClientConfig
 from answer_rocket.graphql.client import GraphQlClient
-from answer_rocket.graphql.schema import UUID as GQL_UUID, MaxMetricAttribute, MaxDomainObject, \
-    MaxDimensionEntity, MaxFactEntity, MaxNormalAttribute, \
+from answer_rocket.graphql.schema import UUID as GQL_UUID, MaxMetricAttribute, MaxDimensionEntity, MaxFactEntity, \
+    MaxNormalAttribute, \
     MaxPrimaryAttribute, MaxReferenceAttribute, MaxCalculatedMetric, MaxDataset, MaxCalculatedAttribute, \
-    MaxMutationResponse, DateTime, MaxPreQueryNode, RunMaxSqlGenResponse, JSON
+    MaxMutationResponse, DateTime, RunMaxSqlGenResponse, JSON, RunSqlAiResponse
 from answer_rocket.types import MaxResult, RESULT_EXCEPTION_CODE
 
 
@@ -415,6 +414,50 @@ class Data:
             run_max_sql_gen_response = result.run_max_sql_gen
 
             return run_max_sql_gen_response
+        except Exception as e:
+            return None
+
+    def run_sql_ai(self, dataset_id: UUID, question: str, copilot_id: Optional[UUID] = None) -> Optional[RunSqlAiResponse]:
+        try:
+            """
+            dataset_id: the UUID of the dataset
+            question: the NL question
+            copilot_id: optional UUID of the copilot
+            """
+
+            query_args = {
+                'datasetId': str(dataset_id),
+                'question': question,
+                'copilotId': str(copilot_id) if copilot_id else str(self.copilot_id) if self.copilot_id else None
+            }
+
+            query_vars = {
+                'dataset_id': Arg(non_null(GQL_UUID)),
+                'question': Arg(non_null(String)),
+                'copilot_id': Arg(GQL_UUID),
+            }
+
+            operation = self._gql_client.query(variables=query_vars)
+
+            gql_query = operation.run_sql_ai(
+                dataset_id=Variable('dataset_id'),
+                question=Variable('question'),
+                copilot_id=Variable('copilot_id'),
+            )
+
+            gql_query.success()
+            gql_query.code()
+            gql_query.error()
+            gql_query.system_prompt()
+            gql_query.sql_ai_graph()
+            gql_query.sql()
+            gql_query.data()
+
+            result = self._gql_client.submit(operation, query_args)
+
+            run_sql_ai_response = result.run_sql_ai
+
+            return run_sql_ai_response
         except Exception as e:
             return None
 

--- a/answer_rocket/data.py
+++ b/answer_rocket/data.py
@@ -410,6 +410,7 @@ class Data:
             gql_query.code()
             gql_query.error()
             gql_query.sql()
+            gql_query.row_limit()
             gql_query.data()
 
             result = self._gql_client.submit(operation, query_args)

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -858,11 +858,12 @@ class Query(sgqlc.types.Type):
 
 class RunMaxSqlGenResponse(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('success', 'code', 'error', 'sql', 'data')
+    __field_names__ = ('success', 'code', 'error', 'sql', 'row_limit', 'data')
     success = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='success')
     code = sgqlc.types.Field(String, graphql_name='code')
     error = sgqlc.types.Field(String, graphql_name='error')
     sql = sgqlc.types.Field(String, graphql_name='sql')
+    row_limit = sgqlc.types.Field(Int, graphql_name='rowLimit')
     data = sgqlc.types.Field(JSON, graphql_name='data')
 
 

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -40,11 +40,6 @@ class LlmResponse(sgqlc.types.Scalar):
     __schema__ = schema
 
 
-class MaxPreQueryOperator(sgqlc.types.Enum):
-    __schema__ = schema
-    __choices__ = ('BETWEEN', 'ENDS_WITH', 'EQUALS', 'GREATER_THAN', 'GREATER_THAN_EQUALS', 'IN', 'LESS_THAN', 'LESS_THAN_EQUALS', 'LIKE', 'NOT_BETWEEN', 'NOT_ENDS_WITH', 'NOT_EQUALS', 'NOT_IN', 'NOT_LIKE', 'NOT_NULL', 'NOT_STARTS_WITH', 'NULL', 'STARTS_WITH')
-
-
 class MetricType(sgqlc.types.Enum):
     __schema__ = schema
     __choices__ = ('BASIC', 'RATIO', 'SHARE')
@@ -552,71 +547,6 @@ class MaxMutationResponse(sgqlc.types.Type):
     error = sgqlc.types.Field(String, graphql_name='error')
 
 
-class MaxPreQueryDimension(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('name', 'alias', 'sql')
-    name = sgqlc.types.Field(String, graphql_name='name')
-    alias = sgqlc.types.Field(String, graphql_name='alias')
-    sql = sgqlc.types.Field(String, graphql_name='sql')
-
-
-class MaxPreQueryDimensionFilter(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('domain_object_name', 'op', 'val')
-    domain_object_name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='domainObjectName')
-    op = sgqlc.types.Field(sgqlc.types.non_null(MaxPreQueryOperator), graphql_name='op')
-    val = sgqlc.types.Field(String, graphql_name='val')
-
-
-class MaxPreQueryFilter(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('domain_object_name', 'op', 'val')
-    domain_object_name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='domainObjectName')
-    op = sgqlc.types.Field(sgqlc.types.non_null(MaxPreQueryOperator), graphql_name='op')
-    val = sgqlc.types.Field(String, graphql_name='val')
-
-
-class MaxPreQueryMetric(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('name', 'alias', 'sql')
-    name = sgqlc.types.Field(String, graphql_name='name')
-    alias = sgqlc.types.Field(String, graphql_name='alias')
-    sql = sgqlc.types.Field(String, graphql_name='sql')
-
-
-class MaxPreQueryMetricFilter(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('domain_object_name', 'op', 'val', 'is_row_level')
-    domain_object_name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='domainObjectName')
-    op = sgqlc.types.Field(sgqlc.types.non_null(MaxPreQueryOperator), graphql_name='op')
-    val = sgqlc.types.Field(String, graphql_name='val')
-    is_row_level = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='isRowLevel')
-
-
-class MaxPreQueryNode(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('name', 'child_nodes', 'qualifier_nodes', 'metrics', 'dimensions', 'dimension_filters', 'metric_filters', 'sorts', 'limit', 'dimension_filter_or_blocks')
-    name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='name')
-    child_nodes = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null('MaxPreQueryNode'))), graphql_name='childNodes')
-    qualifier_nodes = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null('MaxPreQueryNode'))), graphql_name='qualifierNodes')
-    metrics = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxPreQueryMetric))), graphql_name='metrics')
-    dimensions = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxPreQueryDimension))), graphql_name='dimensions')
-    dimension_filters = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxPreQueryDimensionFilter))), graphql_name='dimensionFilters')
-    metric_filters = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxPreQueryMetricFilter))), graphql_name='metricFilters')
-    sorts = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null('MaxPreQuerySort'))), graphql_name='sorts')
-    limit = sgqlc.types.Field(Int, graphql_name='limit')
-    dimension_filter_or_blocks = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxPreQueryFilter))))), graphql_name='dimensionFilterOrBlocks')
-
-
-class MaxPreQuerySort(sgqlc.types.Type):
-    __schema__ = schema
-    __field_names__ = ('domain_object_name', 'sql', 'is_descending', 'select_alias')
-    domain_object_name = sgqlc.types.Field(String, graphql_name='domainObjectName')
-    sql = sgqlc.types.Field(String, graphql_name='sql')
-    is_descending = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='isDescending')
-    select_alias = sgqlc.types.Field(String, graphql_name='selectAlias')
-
-
 class MaxReportParamsAndValues(sgqlc.types.Type):
     __schema__ = schema
     __field_names__ = ('key', 'values', 'label', 'color')
@@ -799,7 +729,7 @@ class Mutation(sgqlc.types.Type):
 
 class Query(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'run_max_sql_gen', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries', 'chat_completion', 'narrative_completion')
+    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'run_max_sql_gen', 'run_sql_ai', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries', 'chat_completion', 'narrative_completion')
     ping = sgqlc.types.Field(String, graphql_name='ping')
     current_user = sgqlc.types.Field(MaxUser, graphql_name='currentUser')
     get_copilot_skill_artifact_by_path = sgqlc.types.Field(CopilotSkillArtifact, graphql_name='getCopilotSkillArtifactByPath', args=sgqlc.types.ArgDict((
@@ -868,6 +798,12 @@ class Query(sgqlc.types.Type):
         ('copilot_id', sgqlc.types.Arg(UUID, graphql_name='copilotId', default=None)),
 ))
     )
+    run_sql_ai = sgqlc.types.Field('RunSqlAiResponse', graphql_name='runSqlAi', args=sgqlc.types.ArgDict((
+        ('dataset_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='datasetId', default=None)),
+        ('question', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='question', default=None)),
+        ('copilot_id', sgqlc.types.Arg(UUID, graphql_name='copilotId', default=None)),
+))
+    )
     llmapi_config_for_sdk = sgqlc.types.Field(LLMApiConfig, graphql_name='LLMApiConfigForSdk', args=sgqlc.types.ArgDict((
         ('model_type', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='modelType', default=None)),
 ))
@@ -926,6 +862,18 @@ class RunMaxSqlGenResponse(sgqlc.types.Type):
     success = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='success')
     code = sgqlc.types.Field(String, graphql_name='code')
     error = sgqlc.types.Field(String, graphql_name='error')
+    sql = sgqlc.types.Field(String, graphql_name='sql')
+    data = sgqlc.types.Field(JSON, graphql_name='data')
+
+
+class RunSqlAiResponse(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('success', 'code', 'error', 'system_prompt', 'sql_ai_graph', 'sql', 'data')
+    success = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='success')
+    code = sgqlc.types.Field(String, graphql_name='code')
+    error = sgqlc.types.Field(String, graphql_name='error')
+    system_prompt = sgqlc.types.Field(String, graphql_name='systemPrompt')
+    sql_ai_graph = sgqlc.types.Field(JSON, graphql_name='sqlAiGraph')
     sql = sgqlc.types.Field(String, graphql_name='sql')
     data = sgqlc.types.Field(JSON, graphql_name='data')
 

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -40,6 +40,11 @@ class LlmResponse(sgqlc.types.Scalar):
     __schema__ = schema
 
 
+class MaxPreQueryOperator(sgqlc.types.Enum):
+    __schema__ = schema
+    __choices__ = ('BETWEEN', 'ENDS_WITH', 'EQUALS', 'GREATER_THAN', 'GREATER_THAN_EQUALS', 'IN', 'LESS_THAN', 'LESS_THAN_EQUALS', 'LIKE', 'NOT_BETWEEN', 'NOT_ENDS_WITH', 'NOT_EQUALS', 'NOT_IN', 'NOT_LIKE', 'NOT_NULL', 'NOT_STARTS_WITH', 'NULL', 'STARTS_WITH')
+
+
 class MetricType(sgqlc.types.Enum):
     __schema__ = schema
     __choices__ = ('BASIC', 'RATIO', 'SHARE')
@@ -547,6 +552,71 @@ class MaxMutationResponse(sgqlc.types.Type):
     error = sgqlc.types.Field(String, graphql_name='error')
 
 
+class MaxPreQueryDimension(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('name', 'alias', 'sql')
+    name = sgqlc.types.Field(String, graphql_name='name')
+    alias = sgqlc.types.Field(String, graphql_name='alias')
+    sql = sgqlc.types.Field(String, graphql_name='sql')
+
+
+class MaxPreQueryDimensionFilter(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('domain_object_name', 'op', 'val')
+    domain_object_name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='domainObjectName')
+    op = sgqlc.types.Field(sgqlc.types.non_null(MaxPreQueryOperator), graphql_name='op')
+    val = sgqlc.types.Field(String, graphql_name='val')
+
+
+class MaxPreQueryFilter(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('domain_object_name', 'op', 'val')
+    domain_object_name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='domainObjectName')
+    op = sgqlc.types.Field(sgqlc.types.non_null(MaxPreQueryOperator), graphql_name='op')
+    val = sgqlc.types.Field(String, graphql_name='val')
+
+
+class MaxPreQueryMetric(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('name', 'alias', 'sql')
+    name = sgqlc.types.Field(String, graphql_name='name')
+    alias = sgqlc.types.Field(String, graphql_name='alias')
+    sql = sgqlc.types.Field(String, graphql_name='sql')
+
+
+class MaxPreQueryMetricFilter(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('domain_object_name', 'op', 'val', 'is_row_level')
+    domain_object_name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='domainObjectName')
+    op = sgqlc.types.Field(sgqlc.types.non_null(MaxPreQueryOperator), graphql_name='op')
+    val = sgqlc.types.Field(String, graphql_name='val')
+    is_row_level = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='isRowLevel')
+
+
+class MaxPreQueryNode(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('name', 'child_nodes', 'qualifier_nodes', 'metrics', 'dimensions', 'dimension_filters', 'metric_filters', 'sorts', 'limit', 'dimension_filter_or_blocks')
+    name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='name')
+    child_nodes = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null('MaxPreQueryNode'))), graphql_name='childNodes')
+    qualifier_nodes = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null('MaxPreQueryNode'))), graphql_name='qualifierNodes')
+    metrics = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxPreQueryMetric))), graphql_name='metrics')
+    dimensions = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxPreQueryDimension))), graphql_name='dimensions')
+    dimension_filters = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxPreQueryDimensionFilter))), graphql_name='dimensionFilters')
+    metric_filters = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxPreQueryMetricFilter))), graphql_name='metricFilters')
+    sorts = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null('MaxPreQuerySort'))), graphql_name='sorts')
+    limit = sgqlc.types.Field(Int, graphql_name='limit')
+    dimension_filter_or_blocks = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxPreQueryFilter))))), graphql_name='dimensionFilterOrBlocks')
+
+
+class MaxPreQuerySort(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('domain_object_name', 'sql', 'is_descending', 'select_alias')
+    domain_object_name = sgqlc.types.Field(String, graphql_name='domainObjectName')
+    sql = sgqlc.types.Field(String, graphql_name='sql')
+    is_descending = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='isDescending')
+    select_alias = sgqlc.types.Field(String, graphql_name='selectAlias')
+
+
 class MaxReportParamsAndValues(sgqlc.types.Type):
     __schema__ = schema
     __field_names__ = ('key', 'values', 'label', 'color')
@@ -729,7 +799,7 @@ class Mutation(sgqlc.types.Type):
 
 class Query(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries', 'chat_completion', 'narrative_completion')
+    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'run_max_sql_gen', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries', 'chat_completion', 'narrative_completion')
     ping = sgqlc.types.Field(String, graphql_name='ping')
     current_user = sgqlc.types.Field(MaxUser, graphql_name='currentUser')
     get_copilot_skill_artifact_by_path = sgqlc.types.Field(CopilotSkillArtifact, graphql_name='getCopilotSkillArtifactByPath', args=sgqlc.types.ArgDict((
@@ -792,6 +862,12 @@ class Query(sgqlc.types.Type):
         ('rql_name', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='rqlName', default=None)),
 ))
     )
+    run_max_sql_gen = sgqlc.types.Field('RunMaxSqlGenResponse', graphql_name='runMaxSqlGen', args=sgqlc.types.ArgDict((
+        ('dataset_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='datasetId', default=None)),
+        ('pre_query_object', sgqlc.types.Arg(JSON, graphql_name='preQueryObject', default=None)),
+        ('copilot_id', sgqlc.types.Arg(UUID, graphql_name='copilotId', default=None)),
+))
+    )
     llmapi_config_for_sdk = sgqlc.types.Field(LLMApiConfig, graphql_name='LLMApiConfigForSdk', args=sgqlc.types.ArgDict((
         ('model_type', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='modelType', default=None)),
 ))
@@ -842,6 +918,16 @@ class Query(sgqlc.types.Type):
         ('model_selection', sgqlc.types.Arg(LlmModelSelection, graphql_name='modelSelection', default=None)),
 ))
     )
+
+
+class RunMaxSqlGenResponse(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('success', 'code', 'error', 'sql', 'data')
+    success = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='success')
+    code = sgqlc.types.Field(String, graphql_name='code')
+    error = sgqlc.types.Field(String, graphql_name='error')
+    sql = sgqlc.types.Field(String, graphql_name='sql')
+    data = sgqlc.types.Field(JSON, graphql_name='data')
 
 
 class SharedThread(sgqlc.types.Type):


### PR DESCRIPTION
This PR adds two new functions to the `data` object:

- `run_max_sql_gen()`
- `run_sql_ai()`

An example of calling `run_sql_ai()` is below.  I have not yet added any builder classes for this.  @jpleoAR @hetul18 please provide feedback on how important you feel that will be.

```
pre_query_node_dict = {
    "__type": "PreQueryNode",
    "metrics": [
        {
            "__type": "PreQueryMetric",
            "name": "sales",
        },
        {
            "__type": "PreQueryMetric",
            "name": "acv",
        }
    ],
    "dimensions": [
        {
            "__type": "PreQueryDimension",
            "name": "segment",
        }
    ],
    "dimension_filters": [
        {
            "__type": "PreQueryDimensionFilter",
            "domain_object_name": "segment",
            "op": "in",
            "val": ["long cut", "short cut"]
        }
    ]
}

# Pasta V9
response = max.data.run_max_sql_gen(uuid.UUID("14986a23-4d3f-445b-85f4-caf1dfeafe6c"), pre_query_node_dict)
```

<img width="881" alt="image" src="https://github.com/user-attachments/assets/6c87af8d-343b-44b8-bfdf-4049aebc3c07" />

===
An example of calling `run_sql_ai()` is below.

```
question = "what were sales by segment in 2022?"

# Pasta V9
response = max.data.run_sql_ai(uuid.UUID("14986a23-4d3f-445b-85f4-caf1dfeafe6c"), question)
```

<img width="873" alt="image" src="https://github.com/user-attachments/assets/b05e367d-254f-42d9-858a-7850c46eb838" />

@PGAnswerRocket the `data` field is not populated yet, but will be once we your code is integrated on the Max server side.
