### PR TITLE
thread_id and chat_entry_id in client config + skill memory operations

### DIFF
--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -5,7 +5,7 @@ from sgqlc.types import Variable, non_null, String, Arg, list_of
 
 from answer_rocket.graphql.client import GraphQlClient
 from answer_rocket.graphql.schema import (UUID, Int, DateTime, ChatDryRunType, MaxChatEntry, MaxChatThread,
-                                          SharedThread, MaxChatUser)
+                                          SharedThread, MaxChatUser, JSON)
 from answer_rocket.graphql.sdk_operations import Operations
 
 logger = logging.getLogger(__name__)
@@ -381,3 +381,32 @@ class Chat:
         result = self.gql_client.submit(operation, get_all_chat_entries_query_args)
 
         return result.all_chat_entries
+    
+    def get_skill_memory_payload(self, chat_entry_id: str) -> JSON:
+        """
+        Fetches the skill memory payload for a given chat entry.
+        :param chat_entry_id: the id of the chat entry
+        :return: the skill memory payload for the given chat entry
+        """
+        skill_memory_args = {
+            'entryId': UUID(chat_entry_id),
+        }
+        op = Operations.query.skill_memory
+        result = self.gql_client.submit(op, skill_memory_args)
+        return result.skill_memory
+
+    def set_skill_memory_payload(self, chat_entry_id: str, skill_memory_payload: JSON) -> bool:
+        """
+        Sets the skill memory payload for a given chat entry.
+        :param chat_entry_id: the id of the chat entry
+        :param skill_memory_payload: the skill memory payload to set
+        :return: True if the skill memory payload was set successfully, False otherwise
+        """
+        set_skill_memory_args = {
+            'entryId': UUID(chat_entry_id),
+            'skillMemoryPayload': skill_memory_payload,
+        }
+        op = Operations.mutation.set_skill_memory
+        result = self.gql_client.submit(op, set_skill_memory_args)
+        return result.set_skill_memory
+

--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -5,7 +5,7 @@ from sgqlc.types import Variable, non_null, String, Arg, list_of
 
 from answer_rocket.graphql.client import GraphQlClient
 from answer_rocket.graphql.schema import (UUID, Int, DateTime, ChatDryRunType, MaxChatEntry, MaxChatThread,
-                                          SharedThread, MaxChatUser, JSON)
+                                          SharedThread, MaxChatUser)
 from answer_rocket.graphql.sdk_operations import Operations
 
 logger = logging.getLogger(__name__)
@@ -382,7 +382,7 @@ class Chat:
 
         return result.all_chat_entries
     
-    def get_skill_memory_payload(self, chat_entry_id: str) -> JSON:
+    def get_skill_memory_payload(self, chat_entry_id: str) -> dict:
         """
         Fetches the skill memory payload for a given chat entry.
         :param chat_entry_id: the id of the chat entry
@@ -395,11 +395,11 @@ class Chat:
         result = self.gql_client.submit(op, skill_memory_args)
         return result.skill_memory
 
-    def set_skill_memory_payload(self, chat_entry_id: str, skill_memory_payload: JSON) -> bool:
+    def set_skill_memory_payload(self, chat_entry_id: str, skill_memory_payload: dict) -> bool:
         """
         Sets the skill memory payload for a given chat entry.
         :param chat_entry_id: the id of the chat entry
-        :param skill_memory_payload: the skill memory payload to set
+        :param skill_memory_payload: the skill memory payload to set -- must be JSON serializable
         :return: True if the skill memory payload was set successfully, False otherwise
         """
         set_skill_memory_args = {

--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -7,6 +7,7 @@ from answer_rocket.graphql.client import GraphQlClient
 from answer_rocket.graphql.schema import (UUID, Int, DateTime, ChatDryRunType, MaxChatEntry, MaxChatThread,
                                           SharedThread, MaxChatUser)
 from answer_rocket.graphql.sdk_operations import Operations
+from answer_rocket.client_config import ClientConfig
 
 logger = logging.getLogger(__name__)
 
@@ -14,8 +15,9 @@ FeedbackType = Literal['CHAT_POSITIVE', 'CHAT_NEGATIVE']
 
 
 class Chat:
-    def __init__(self, gql_client: GraphQlClient):
+    def __init__(self, gql_client: GraphQlClient, config: ClientConfig):
         self.gql_client = gql_client
+        self._config = config
 
     def ask_question(self, copilot_id: str, question: str, thread_id: str = None, skip_report_cache: bool = False, dry_run_type: str = None, model_overrides: dict = None, indicated_skills: list[str] = None, history: list[dict] = None):
         """
@@ -395,13 +397,17 @@ class Chat:
         result = self.gql_client.submit(op, skill_memory_args)
         return result.skill_memory
 
-    def set_skill_memory_payload(self, chat_entry_id: str, skill_memory_payload: dict) -> bool:
+    def set_skill_memory_payload(self, skill_memory_payload: dict, chat_entry_id: str = None) -> bool:
         """
         Sets the skill memory payload for a given chat entry.
         :param chat_entry_id: the id of the chat entry
         :param skill_memory_payload: the skill memory payload to set -- must be JSON serializable
         :return: True if the skill memory payload was set successfully, False otherwise
         """
+
+        if chat_entry_id is None:
+            chat_entry_id = self._config.chat_entry_id
+
         set_skill_memory_args = {
             'entryId': UUID(chat_entry_id),
             'skillMemoryPayload': skill_memory_payload,

--- a/answer_rocket/client_config.py
+++ b/answer_rocket/client_config.py
@@ -28,6 +28,8 @@ class ClientConfig:
     copilot_id: str | None
     copilot_skill_id: str | None
     resource_base_path: str | None
+    thread_id: str | None
+    chat_entry_id: str | None
 
 
 def load_client_config(url=None, token=None, tenant: str = None):
@@ -41,6 +43,8 @@ def load_client_config(url=None, token=None, tenant: str = None):
     copilot_skill_id = os.getenv('AR_COPILOT_SKILL_ID')
     is_live_run = os.getenv('AR_IS_RUNNING_ON_FLEET') or False
     resource_base_path = os.getenv('AR_SKILL_RESOURCE_BASE_PATH')
+    thread_id = os.getenv('AR_THREAD_ID')
+    chat_entry_id = os.getenv('AR_CHAT_ENTRY_ID')
     return ClientConfig(
         url=url,
         token=token,
@@ -51,6 +55,8 @@ def load_client_config(url=None, token=None, tenant: str = None):
         entry_answer_id=entry_answer_id,
         copilot_id=copilot_id,
         copilot_skill_id=copilot_skill_id,
-        resource_base_path=resource_base_path
+        resource_base_path=resource_base_path,
+        thread_id=thread_id,
+        chat_entry_id=chat_entry_id
     )
 

--- a/answer_rocket/graphql/operations/chat.gql
+++ b/answer_rocket/graphql/operations/chat.gql
@@ -70,6 +70,7 @@ fragment ChatResultFragment on MaxChatResult {
   }
   threadId
   userId
+  skillMemoryPayload
 }
 
 mutation CancelChatQuestion($entryId: UUID!) {

--- a/answer_rocket/graphql/operations/chat.gql
+++ b/answer_rocket/graphql/operations/chat.gql
@@ -141,3 +141,11 @@ mutation AddFeedback(
 ) {
   addFeedback(entryId: $entryId, feedbackType: $feedbackType, message: $message)
 }
+
+query SkillMemory($entryId: UUID!) {
+  skillMemory(entryId: $entryId)
+}
+
+mutation SetSkillMemory($entryId: UUID!, $skillMemoryPayload: JSON!) {
+  setSkillMemory(entryId: $entryId, skillMemoryPayload: $skillMemoryPayload)
+}

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -620,7 +620,7 @@ class MaxUser(sgqlc.types.Type):
 
 class Mutation(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('create_max_copilot_skill_chat_question', 'update_max_copilot_skill_chat_question', 'delete_max_copilot_skill_chat_question', 'create_max_copilot_question', 'update_max_copilot_question', 'delete_max_copilot_question', 'reload_dataset', 'update_dataset_date_range', 'update_chat_answer_payload', 'ask_chat_question', 'evaluate_chat_question', 'queue_chat_question', 'cancel_chat_question', 'create_chat_thread', 'add_feedback', 'share_thread', 'update_loading_message')
+    __field_names__ = ('create_max_copilot_skill_chat_question', 'update_max_copilot_skill_chat_question', 'delete_max_copilot_skill_chat_question', 'create_max_copilot_question', 'update_max_copilot_question', 'delete_max_copilot_question', 'reload_dataset', 'update_dataset_date_range', 'update_chat_answer_payload', 'ask_chat_question', 'evaluate_chat_question', 'queue_chat_question', 'cancel_chat_question', 'create_chat_thread', 'add_feedback', 'set_skill_memory', 'share_thread', 'update_loading_message')
     create_max_copilot_skill_chat_question = sgqlc.types.Field(sgqlc.types.non_null(CreateMaxCopilotSkillChatQuestionResponse), graphql_name='createMaxCopilotSkillChatQuestion', args=sgqlc.types.ArgDict((
         ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
         ('copilot_skill_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotSkillId', default=None)),
@@ -716,6 +716,11 @@ class Mutation(sgqlc.types.Type):
         ('message', sgqlc.types.Arg(String, graphql_name='message', default=None)),
 ))
     )
+    set_skill_memory = sgqlc.types.Field(Boolean, graphql_name='setSkillMemory', args=sgqlc.types.ArgDict((
+        ('entry_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='entryId', default=None)),
+        ('skill_memory_payload', sgqlc.types.Arg(sgqlc.types.non_null(JSON), graphql_name='skillMemoryPayload', default=None)),
+))
+    )
     share_thread = sgqlc.types.Field(sgqlc.types.non_null('SharedThread'), graphql_name='shareThread', args=sgqlc.types.ArgDict((
         ('original_thread_id', sgqlc.types.Arg(UUID, graphql_name='originalThreadId', default=None)),
 ))
@@ -729,7 +734,7 @@ class Mutation(sgqlc.types.Type):
 
 class Query(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'run_max_sql_gen', 'run_sql_ai', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries', 'chat_completion', 'narrative_completion')
+    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'execute_sql_query', 'execute_rql_query', 'get_dataset_id', 'get_dataset', 'get_domain_object', 'get_domain_object_by_name', 'run_max_sql_gen', 'run_sql_ai', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries', 'skill_memory', 'chat_completion', 'narrative_completion')
     ping = sgqlc.types.Field(String, graphql_name='ping')
     current_user = sgqlc.types.Field(MaxUser, graphql_name='currentUser')
     get_copilot_skill_artifact_by_path = sgqlc.types.Field(CopilotSkillArtifact, graphql_name='getCopilotSkillArtifactByPath', args=sgqlc.types.ArgDict((
@@ -842,6 +847,10 @@ class Query(sgqlc.types.Type):
         ('offset', sgqlc.types.Arg(Int, graphql_name='offset', default=None)),
         ('limit', sgqlc.types.Arg(Int, graphql_name='limit', default=None)),
         ('filters', sgqlc.types.Arg(JSON, graphql_name='filters', default=None)),
+))
+    )
+    skill_memory = sgqlc.types.Field(JSON, graphql_name='skillMemory', args=sgqlc.types.ArgDict((
+        ('entry_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='entryId', default=None)),
 ))
     )
     chat_completion = sgqlc.types.Field(LlmResponse, graphql_name='chatCompletion', args=sgqlc.types.ArgDict((

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -327,7 +327,7 @@ class MaxChatQuestion(sgqlc.types.Type):
 
 class MaxChatResult(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('answer_id', 'answered_at', 'copilot_skill_id', 'has_finished', 'error', 'is_new_thread', 'message', 'report_results', 'thread_id', 'user_id', 'general_diagnostics', 'chat_pipeline_profile', 'messages_after_token_limit')
+    __field_names__ = ('answer_id', 'answered_at', 'copilot_skill_id', 'has_finished', 'error', 'is_new_thread', 'message', 'report_results', 'thread_id', 'user_id', 'general_diagnostics', 'chat_pipeline_profile', 'messages_after_token_limit', 'skill_memory_payload')
     answer_id = sgqlc.types.Field(UUID, graphql_name='answerId')
     answered_at = sgqlc.types.Field(DateTime, graphql_name='answeredAt')
     copilot_skill_id = sgqlc.types.Field(UUID, graphql_name='copilotSkillId')
@@ -341,6 +341,7 @@ class MaxChatResult(sgqlc.types.Type):
     general_diagnostics = sgqlc.types.Field(JSON, graphql_name='generalDiagnostics')
     chat_pipeline_profile = sgqlc.types.Field(JSON, graphql_name='chatPipelineProfile')
     messages_after_token_limit = sgqlc.types.Field(Int, graphql_name='messagesAfterTokenLimit')
+    skill_memory_payload = sgqlc.types.Field(JSON, graphql_name='skillMemoryPayload')
 
 
 class MaxChatThread(sgqlc.types.Type):

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -77,6 +77,12 @@ def mutation_add_feedback():
     return _op
 
 
+def mutation_set_skill_memory():
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='SetSkillMemory', variables=dict(entryId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), skillMemoryPayload=sgqlc.types.Arg(sgqlc.types.non_null(_schema.JSON))))
+    _op.set_skill_memory(entry_id=sgqlc.types.Variable('entryId'), skill_memory_payload=sgqlc.types.Variable('skillMemoryPayload'))
+    return _op
+
+
 def mutation_update_loading_message():
     _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='UpdateLoadingMessage', variables=dict(answerId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), message=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String))))
     _op.update_loading_message(answer_id=sgqlc.types.Variable('answerId'), message=sgqlc.types.Variable('message'))
@@ -89,6 +95,7 @@ class Mutation:
     cancel_chat_question = mutation_cancel_chat_question()
     create_chat_thread = mutation_create_chat_thread()
     queue_chat_question = mutation_queue_chat_question()
+    set_skill_memory = mutation_set_skill_memory()
     update_loading_message = mutation_update_loading_message()
 
 
@@ -134,6 +141,12 @@ def query_all_chat_entries():
     _op_all_chat_entries_answer.__fragment__(fragment_chat_result_fragment())
     _op_all_chat_entries.feedback()
     _op_all_chat_entries.user()
+    return _op
+
+
+def query_skill_memory():
+    _op = sgqlc.operation.Operation(_schema_root.query_type, name='SkillMemory', variables=dict(entryId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID))))
+    _op.skill_memory(entry_id=sgqlc.types.Variable('entryId'))
     return _op
 
 
@@ -197,6 +210,7 @@ class Query:
     get_copilot_skill = query_get_copilot_skill()
     get_max_llm_prompt = query_get_max_llm_prompt()
     narrative_completion = query_narrative_completion()
+    skill_memory = query_skill_memory()
 
 
 class Operations:

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -30,6 +30,7 @@ def fragment_chat_result_fragment():
     _frag_report_results.custom_payload()
     _frag.thread_id()
     _frag.user_id()
+    _frag.skill_memory_payload()
     return _frag
 
 


### PR DESCRIPTION
added `get_skill_memory_payload(self, chat_entry_id: str) -> JSON:` and `set_skill_memory_payload(self, chat_entry_id: str, skill_memory_payload: JSON) -> bool:` to get and set skill memory payloads on chat entries.