### PR TITLE
Check Connection Upon Initalization

### DIFF
--- a/answer_rocket/client.py
+++ b/answer_rocket/client.py
@@ -26,6 +26,8 @@ class AnswerRocketClient:
 		self.skill = Skill(self._client_config, self._gql_client)
 		self.llm = Llm(self._client_config, self._gql_client)
 
+		self.can_connect()
+
 	def can_connect(self) -> bool:
 		"""
 		utility method for checking that the client can connect to and authenticate with the server it is pointed at


### PR DESCRIPTION
Checking if the AnswerRocketClient can connect to the env when initialized. If it can connect, nothing occurs, otherwise a 401 error is raised.

Adding this because many of our sdk calls have try excepts around the sdk calls, especially in .data. What ends up happening is that the skill errors out down the line rather than within the sdk, so it's difficult to see that the issue is with the sdk connection. Now it'll be clearer if the connection isn't working. 