### PR TITLE
prior_runs

### DIFF
--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -957,7 +957,7 @@ class RunSqlAiResponse(sgqlc.types.Type):
     title = sgqlc.types.Field(String, graphql_name='title')
     explanation = sgqlc.types.Field(String, graphql_name='explanation')
     timing_info = sgqlc.types.Field(JSON, graphql_name='timingInfo')
-    prior_runs = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of('RunSqlAiResponse')), graphql_name='priorRuns')
+    prior_runs = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null('RunSqlAiResponse'))), graphql_name='priorRuns')
 
 
 class SharedThread(sgqlc.types.Type):


### PR DESCRIPTION
This PR handles `prior_runs` better, although the field seems to be getting dropped from the GraphQL call if it's an empty list.  Therefore, I'm using `hasattr()` to check for it, though I wish the field could always be there.

See this PR for Max:  https://bitbucket.org/aglabs/nfl/pull-requests/8518