### PR TITLE
Feature/agent workflow support

### DIFF
--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -581,6 +581,24 @@ class Chat:
         op = Operations.mutation.test_run_copilot_skill
         result = self.gql_client.submit(op, test_run_copilot_skill_args)
         return result.test_run_copilot_skill
+    
+    def get_test_run_output(self, answer_id: str):
+        """
+        TODO: This is meant to be temprorary, used for skill builder and should be removed or reworked once builder is moved internal
+        Gets the output of a test run.
+        :param answer_id: the id of the answer to get the output for
+        :return: the output of the test run
+        """
+        if answer_id is None:
+            logger.warning("No answer id provided, aborting.")
+            return None
+        
+        get_test_run_output_args = {
+            'answerId': UUID(answer_id),
+        }
+        op = Operations.mutation.get_test_run_output
+        result = self.gql_client.submit(op, get_test_run_output_args)
+        return result.get_test_run_output
 
     def get_dataframes_for_entry(self, entry_id: str) -> [pd.DataFrame]:
         """

--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -553,6 +553,34 @@ class Chat:
         op = Operations.mutation.sync_max_skill_repository
         result = self.gql_client.submit(op, sync_max_skill_repository_args)
         return result.sync_max_skill_repository
+    
+    def test_run_copilot_skill(self, copilot_id: str, skill_name: str, nl: str = None, parameters: dict = None):
+        """
+        TODO: This is meant to be temprorary, used for skill builder and should be removed or reworked once builder is moved internal
+        Test runs a copilot skill.
+        :param copilot_id: the id of the copilot    
+        :param skill_name: the name of the skill to test run
+        :param nl: the natural language query to test run
+        :param parameters: the parameters to pass to the skill
+        :return: True if the test run was successful, False otherwise
+        """
+        if copilot_id is None:
+            logger.warning("No copilot id provided, aborting.")
+            return None
+        
+        if skill_name is None:
+            logger.warning("No skill name provided, aborting.")
+            return None
+        
+        test_run_copilot_skill_args = {
+            'copilotId': UUID(copilot_id),
+            'skillName': skill_name,
+            'nl': nl if nl is not None else "",
+            'parameters': parameters,
+        }
+        op = Operations.mutation.test_run_copilot_skill
+        result = self.gql_client.submit(op, test_run_copilot_skill_args)
+        return result.test_run_copilot_skill
 
     def get_dataframes_for_entry(self, entry_id: str) -> [pd.DataFrame]:
         """

--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -502,6 +502,57 @@ class Chat:
         op = Operations.mutation.import_copilot_skill_from_zip
         result = self.gql_client.submit(op, import_copilot_skill_from_zip_args)
         return result.import_copilot_skill_from_zip
+    
+    def import_skill_from_repo(self, copilot_id: str, skill_name: str, repository_id: str):
+        """
+        TODO: This is meant to be temprorary, used for skill builder and should be removed or reworked once builder is moved internal
+        Imports an agent workflow from a repository.
+        :param copilot_id: the id of the copilot
+        :param skill_name: the name of the skill to import the workflow for
+
+        :param repository_id: the id of the repository to import from
+        :return: True if the workflow was imported successfully, False otherwise
+        """
+
+        if copilot_id is None:
+            logger.warning("No copilot id provided, aborting.")
+            return None
+        
+        if skill_name is None:
+            logger.warning("No skill name provided, aborting.")
+            return None
+        
+        if repository_id is None:
+            logger.warning("No repository id provided, aborting.")
+            return None 
+        
+        import_skill_from_repo_args = {
+            'copilotId': UUID(copilot_id),
+            'skillName': skill_name,
+            'repositoryId': UUID(repository_id),
+        }
+        op = Operations.mutation.import_skill_from_repo
+        result = self.gql_client.submit(op, import_skill_from_repo_args)
+        return result.import_skill_from_repo
+    
+    def sync_max_skill_repository(self, repository_id: str):
+        """
+        TODO: This is meant to be temprorary, used for skill builder and should be removed or reworked once builder is moved internal
+        Syncs a repository.
+        :param repository_id: the id of the repository to sync
+        :return: True if the repository was synced successfully, False otherwise
+        """
+
+        if repository_id is None:
+            logger.warning("No repository id provided, aborting.")
+            return None
+
+        sync_max_skill_repository_args = {
+            'id': UUID(repository_id),
+        }
+        op = Operations.mutation.sync_max_skill_repository
+        result = self.gql_client.submit(op, sync_max_skill_repository_args)
+        return result.sync_max_skill_repository
 
     def get_dataframes_for_entry(self, entry_id: str) -> [pd.DataFrame]:
         """

--- a/answer_rocket/graphql/operations/chat.gql
+++ b/answer_rocket/graphql/operations/chat.gql
@@ -199,3 +199,17 @@ mutation ImportSkillFromRepo(
 mutation SyncMaxSkillRepository($id: UUID!) {
   syncMaxSkillRepository(id: $id)
 }
+
+mutation TestRunCopilotSkill(
+  $copilotId: UUID!
+  $skillName: String!
+  $nl: String!
+  $parameters: JSON
+) {
+  testRunCopilotSkill(
+    copilotId: $copilotId
+    skillName: $skillName
+    nl: $nl
+    parameters: $parameters
+  )
+}

--- a/answer_rocket/graphql/operations/chat.gql
+++ b/answer_rocket/graphql/operations/chat.gql
@@ -211,5 +211,17 @@ mutation TestRunCopilotSkill(
     skillName: $skillName
     nl: $nl
     parameters: $parameters
-  )
+  ) {
+    success
+    error
+    payload
+  }
+}
+
+mutation GetTestRunOutput($answerId: UUID!) {
+  getTestRunOutput(answerId: $answerId) {
+    success
+    error
+    payload
+  }
 }

--- a/answer_rocket/graphql/operations/chat.gql
+++ b/answer_rocket/graphql/operations/chat.gql
@@ -183,3 +183,19 @@ query GetMaxAgentWorkflow($agentWorkflowId: UUID!, $version: Int) {
 mutation ImportCopilotSkillFromZip($entryId: UUID!, $skillName: String!) {
   importCopilotSkillFromZip(entryId: $entryId, skillName: $skillName)
 }
+
+mutation ImportSkillFromRepo(
+  $copilotId: UUID!
+  $skillName: String!
+  $repositoryId: UUID!
+) {
+  importSkillFromRepo(
+    copilotId: $copilotId
+    skillName: $skillName
+    repositoryId: $repositoryId
+  )
+}
+
+mutation SyncMaxSkillRepository($id: UUID!) {
+  syncMaxSkillRepository(id: $id)
+}

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -16,6 +16,11 @@ class ChatDryRunType(sgqlc.types.Enum):
     __choices__ = ('SKIP_SKILL_EXEC', 'SKIP_SKILL_NLG')
 
 
+class ContentBlockType(sgqlc.types.Enum):
+    __schema__ = schema
+    __choices__ = ('INSIGHTS', 'VISUAL')
+
+
 class DatasetDataInterval(sgqlc.types.Enum):
     __schema__ = schema
     __choices__ = ('DATE', 'MONTH', 'QUARTER', 'WEEK', 'YEAR')
@@ -85,6 +90,15 @@ class UUID(sgqlc.types.Scalar):
 ########################################################################
 # Input Objects
 ########################################################################
+class ChatArtifactSearchInput(sgqlc.types.Input):
+    __schema__ = schema
+    __field_names__ = ('name_contains', 'created_utc_start', 'created_utc_end', 'misc_info')
+    name_contains = sgqlc.types.Field(String, graphql_name='nameContains')
+    created_utc_start = sgqlc.types.Field(DateTime, graphql_name='createdUtcStart')
+    created_utc_end = sgqlc.types.Field(DateTime, graphql_name='createdUtcEnd')
+    misc_info = sgqlc.types.Field(JSON, graphql_name='miscInfo')
+
+
 class FunctionCallMessageInput(sgqlc.types.Input):
     __schema__ = schema
     __field_names__ = ('name', 'arguments')
@@ -129,6 +143,13 @@ class ModelOverride(sgqlc.types.Input):
     __field_names__ = ('model_type', 'model_name')
     model_type = sgqlc.types.Field(sgqlc.types.non_null(ModelTypes), graphql_name='modelType')
     model_name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='modelName')
+
+
+class PagingInput(sgqlc.types.Input):
+    __schema__ = schema
+    __field_names__ = ('page_num', 'page_size')
+    page_num = sgqlc.types.Field(sgqlc.types.non_null(Int), graphql_name='pageNum')
+    page_size = sgqlc.types.Field(sgqlc.types.non_null(Int), graphql_name='pageSize')
 
 
 
@@ -231,12 +252,44 @@ class MaxDomainEntity(sgqlc.types.Interface):
     attributes = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(MaxDomainAttribute))), graphql_name='attributes')
 
 
+class BlockData(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('answer_id', 'block_index', 'content_block')
+    answer_id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='answerId')
+    block_index = sgqlc.types.Field(sgqlc.types.non_null(Int), graphql_name='blockIndex')
+    content_block = sgqlc.types.Field(sgqlc.types.non_null('ContentBlock'), graphql_name='contentBlock')
+
+
+class ChatArtifact(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('chat_artifact_id', 'name', 'owner_user_id', 'chat_entry_id', 'content_block_id', 'block_data', 'misc_info', 'created_utc')
+    chat_artifact_id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='chatArtifactId')
+    name = sgqlc.types.Field(String, graphql_name='name')
+    owner_user_id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='ownerUserId')
+    chat_entry_id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='chatEntryId')
+    content_block_id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='contentBlockId')
+    block_data = sgqlc.types.Field(BlockData, graphql_name='blockData')
+    misc_info = sgqlc.types.Field(JSON, graphql_name='miscInfo')
+    created_utc = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='createdUtc')
+
+
 class ChatFeedback(sgqlc.types.Type):
     __schema__ = schema
     __field_names__ = ('type', 'feedback', 'user_id')
     type = sgqlc.types.Field(String, graphql_name='type')
     feedback = sgqlc.types.Field(JSON, graphql_name='feedback')
     user_id = sgqlc.types.Field(UUID, graphql_name='userId')
+
+
+class ContentBlock(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('id', 'title', 'payload', 'layout_json', 'type', 'export_as_landscape')
+    id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='id')
+    title = sgqlc.types.Field(String, graphql_name='title')
+    payload = sgqlc.types.Field(String, graphql_name='payload')
+    layout_json = sgqlc.types.Field(String, graphql_name='layoutJson')
+    type = sgqlc.types.Field(ContentBlockType, graphql_name='type')
+    export_as_landscape = sgqlc.types.Field(Boolean, graphql_name='exportAsLandscape')
 
 
 class CopilotSkillArtifact(sgqlc.types.Type):
@@ -810,7 +863,7 @@ class MaxUser(sgqlc.types.Type):
 
 class Mutation(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('create_max_copilot_skill_chat_question', 'update_max_copilot_skill_chat_question', 'delete_max_copilot_skill_chat_question', 'create_max_copilot_question', 'update_max_copilot_question', 'delete_max_copilot_question', 'set_max_agent_workflow', 'import_copilot_skill_from_zip', 'reload_dataset', 'update_database_name', 'update_database_description', 'update_database_llm_description', 'update_database_mermaid_er_diagram', 'update_database_kshot_limit', 'update_dataset_name', 'update_dataset_description', 'update_dataset_date_range', 'update_dataset_data_interval', 'update_dataset_misc_info', 'update_dataset_source', 'update_dataset_query_row_limit', 'update_dataset_use_database_casing', 'update_dataset_kshot_limit', 'create_dataset', 'create_dimension', 'update_dimension', 'delete_dimension', 'create_metric', 'update_metric', 'delete_metric', 'update_chat_answer_payload', 'ask_chat_question', 'evaluate_chat_question', 'queue_chat_question', 'cancel_chat_question', 'create_chat_thread', 'add_feedback', 'set_skill_memory', 'share_thread', 'update_loading_message')
+    __field_names__ = ('create_max_copilot_skill_chat_question', 'update_max_copilot_skill_chat_question', 'delete_max_copilot_skill_chat_question', 'create_max_copilot_question', 'update_max_copilot_question', 'delete_max_copilot_question', 'set_max_agent_workflow', 'import_copilot_skill_from_zip', 'sync_max_skill_repository', 'import_skill_from_repo', 'reload_dataset', 'update_database_name', 'update_database_description', 'update_database_llm_description', 'update_database_mermaid_er_diagram', 'update_database_kshot_limit', 'update_dataset_name', 'update_dataset_description', 'update_dataset_date_range', 'update_dataset_data_interval', 'update_dataset_misc_info', 'update_dataset_source', 'update_dataset_query_row_limit', 'update_dataset_use_database_casing', 'update_dataset_kshot_limit', 'create_dataset', 'create_dimension', 'update_dimension', 'delete_dimension', 'create_metric', 'update_metric', 'delete_metric', 'update_chat_answer_payload', 'ask_chat_question', 'evaluate_chat_question', 'queue_chat_question', 'cancel_chat_question', 'create_chat_thread', 'add_feedback', 'set_skill_memory', 'share_thread', 'update_loading_message', 'create_chat_artifact', 'delete_chat_artifact')
     create_max_copilot_skill_chat_question = sgqlc.types.Field(sgqlc.types.non_null(CreateMaxCopilotSkillChatQuestionResponse), graphql_name='createMaxCopilotSkillChatQuestion', args=sgqlc.types.ArgDict((
         ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
         ('copilot_skill_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotSkillId', default=None)),
@@ -855,6 +908,16 @@ class Mutation(sgqlc.types.Type):
     )
     import_copilot_skill_from_zip = sgqlc.types.Field(sgqlc.types.non_null(MaxMutationResponse), graphql_name='importCopilotSkillFromZip', args=sgqlc.types.ArgDict((
         ('entry_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='entryId', default=None)),
+        ('skill_name', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='skillName', default=None)),
+))
+    )
+    sync_max_skill_repository = sgqlc.types.Field(sgqlc.types.non_null(MaxMutationResponse), graphql_name='syncMaxSkillRepository', args=sgqlc.types.ArgDict((
+        ('id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='id', default=None)),
+))
+    )
+    import_skill_from_repo = sgqlc.types.Field(sgqlc.types.non_null(MaxMutationResponse), graphql_name='importSkillFromRepo', args=sgqlc.types.ArgDict((
+        ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
+        ('repository_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='repositoryId', default=None)),
         ('skill_name', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='skillName', default=None)),
 ))
     )
@@ -1036,11 +1099,26 @@ class Mutation(sgqlc.types.Type):
         ('nudge_entry_id', sgqlc.types.Arg(UUID, graphql_name='nudgeEntryId', default=None)),
 ))
     )
+    create_chat_artifact = sgqlc.types.Field(sgqlc.types.non_null(MaxMutationResponse), graphql_name='createChatArtifact', args=sgqlc.types.ArgDict((
+        ('chat_artifact', sgqlc.types.Arg(sgqlc.types.non_null(JSON), graphql_name='chatArtifact', default=None)),
+))
+    )
+    delete_chat_artifact = sgqlc.types.Field(sgqlc.types.non_null(MaxMutationResponse), graphql_name='deleteChatArtifact', args=sgqlc.types.ArgDict((
+        ('chat_artifact_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='chatArtifactId', default=None)),
+))
+    )
+
+
+class PagedChatArtifacts(sgqlc.types.Type):
+    __schema__ = schema
+    __field_names__ = ('total_rows', 'rows')
+    total_rows = sgqlc.types.Field(sgqlc.types.non_null(Int), graphql_name='totalRows')
+    rows = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(ChatArtifact))), graphql_name='rows')
 
 
 class Query(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilots', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'get_max_agent_workflow', 'execute_sql_query', 'execute_rql_query', 'get_database', 'get_dataset_id', 'get_dataset', 'get_dataset2', 'get_domain_object', 'get_domain_object_by_name', 'get_grounded_value', 'run_max_sql_gen', 'run_sql_ai', 'generate_visualization', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries', 'skill_memory', 'chat_completion', 'narrative_completion', 'narrative_completion_with_prompt', 'sql_completion', 'research_completion')
+    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilots', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'get_max_agent_workflow', 'execute_sql_query', 'execute_rql_query', 'get_database', 'get_dataset_id', 'get_dataset', 'get_dataset2', 'get_domain_object', 'get_domain_object_by_name', 'get_grounded_value', 'run_max_sql_gen', 'run_sql_ai', 'generate_visualization', 'llmapi_config_for_sdk', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries', 'skill_memory', 'chat_completion', 'narrative_completion', 'narrative_completion_with_prompt', 'sql_completion', 'research_completion', 'get_chat_artifact', 'get_chat_artifacts')
     ping = sgqlc.types.Field(String, graphql_name='ping')
     current_user = sgqlc.types.Field(MaxUser, graphql_name='currentUser')
     get_copilot_skill_artifact_by_path = sgqlc.types.Field(CopilotSkillArtifact, graphql_name='getCopilotSkillArtifactByPath', args=sgqlc.types.ArgDict((
@@ -1212,6 +1290,15 @@ class Query(sgqlc.types.Type):
     research_completion = sgqlc.types.Field(LlmResponse, graphql_name='researchCompletion', args=sgqlc.types.ArgDict((
         ('messages', sgqlc.types.Arg(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(LlmChatMessage))), graphql_name='messages', default=None)),
         ('model_selection', sgqlc.types.Arg(LlmModelSelection, graphql_name='modelSelection', default=None)),
+))
+    )
+    get_chat_artifact = sgqlc.types.Field(ChatArtifact, graphql_name='getChatArtifact', args=sgqlc.types.ArgDict((
+        ('chat_artifact_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='chatArtifactId', default=None)),
+))
+    )
+    get_chat_artifacts = sgqlc.types.Field(sgqlc.types.non_null(PagedChatArtifacts), graphql_name='getChatArtifacts', args=sgqlc.types.ArgDict((
+        ('search_input', sgqlc.types.Arg(sgqlc.types.non_null(ChatArtifactSearchInput), graphql_name='searchInput', default=None)),
+        ('paging', sgqlc.types.Arg(sgqlc.types.non_null(PagingInput), graphql_name='paging', default=None)),
 ))
     )
 

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -611,7 +611,7 @@ class MaxCopilotQuestion(sgqlc.types.Type):
 
 class MaxCopilotSkill(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('copilot_skill_id', 'name', 'copilot_skill_type', 'detailed_name', 'description', 'detailed_description', 'dataset_id', 'parameters', 'skill_chat_questions', 'yaml_code', 'skill_code', 'misc_info', 'scheduling_only', 'copilot_skill_nodes')
+    __field_names__ = ('copilot_skill_id', 'name', 'copilot_skill_type', 'detailed_name', 'description', 'detailed_description', 'dataset_id', 'parameters', 'skill_chat_questions', 'yaml_code', 'skill_code', 'misc_info', 'scheduling_only', 'copilot_skill_nodes', 'capabilities', 'limitations', 'example_questions', 'parameter_guidance')
     copilot_skill_id = sgqlc.types.Field(sgqlc.types.non_null(UUID), graphql_name='copilotSkillId')
     name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='name')
     copilot_skill_type = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='copilotSkillType')
@@ -626,6 +626,10 @@ class MaxCopilotSkill(sgqlc.types.Type):
     misc_info = sgqlc.types.Field(JSON, graphql_name='miscInfo')
     scheduling_only = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='schedulingOnly')
     copilot_skill_nodes = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null('MaxCopilotSkillNode'))), graphql_name='copilotSkillNodes')
+    capabilities = sgqlc.types.Field(String, graphql_name='capabilities')
+    limitations = sgqlc.types.Field(String, graphql_name='limitations')
+    example_questions = sgqlc.types.Field(String, graphql_name='exampleQuestions')
+    parameter_guidance = sgqlc.types.Field(String, graphql_name='parameterGuidance')
 
 
 class MaxCopilotSkillChatQuestion(sgqlc.types.Type):
@@ -863,7 +867,7 @@ class MaxUser(sgqlc.types.Type):
 
 class Mutation(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('create_max_copilot_skill_chat_question', 'update_max_copilot_skill_chat_question', 'delete_max_copilot_skill_chat_question', 'create_max_copilot_question', 'update_max_copilot_question', 'delete_max_copilot_question', 'set_max_agent_workflow', 'import_copilot_skill_from_zip', 'sync_max_skill_repository', 'import_skill_from_repo', 'reload_dataset', 'update_database_name', 'update_database_description', 'update_database_llm_description', 'update_database_mermaid_er_diagram', 'update_database_kshot_limit', 'update_dataset_name', 'update_dataset_description', 'update_dataset_date_range', 'update_dataset_data_interval', 'update_dataset_misc_info', 'update_dataset_source', 'update_dataset_query_row_limit', 'update_dataset_use_database_casing', 'update_dataset_kshot_limit', 'create_dataset', 'create_dimension', 'update_dimension', 'delete_dimension', 'create_metric', 'update_metric', 'delete_metric', 'update_chat_answer_payload', 'ask_chat_question', 'evaluate_chat_question', 'queue_chat_question', 'cancel_chat_question', 'create_chat_thread', 'add_feedback', 'set_skill_memory', 'share_thread', 'update_loading_message', 'create_chat_artifact', 'delete_chat_artifact')
+    __field_names__ = ('create_max_copilot_skill_chat_question', 'update_max_copilot_skill_chat_question', 'delete_max_copilot_skill_chat_question', 'create_max_copilot_question', 'update_max_copilot_question', 'delete_max_copilot_question', 'set_max_agent_workflow', 'import_copilot_skill_from_zip', 'sync_max_skill_repository', 'import_skill_from_repo', 'test_run_copilot_skill', 'reload_dataset', 'update_database_name', 'update_database_description', 'update_database_llm_description', 'update_database_mermaid_er_diagram', 'update_database_kshot_limit', 'update_dataset_name', 'update_dataset_description', 'update_dataset_date_range', 'update_dataset_data_interval', 'update_dataset_misc_info', 'update_dataset_source', 'update_dataset_query_row_limit', 'update_dataset_use_database_casing', 'update_dataset_kshot_limit', 'create_dataset', 'create_dimension', 'update_dimension', 'delete_dimension', 'create_metric', 'update_metric', 'delete_metric', 'update_chat_answer_payload', 'ask_chat_question', 'evaluate_chat_question', 'queue_chat_question', 'cancel_chat_question', 'create_chat_thread', 'add_feedback', 'set_skill_memory', 'share_thread', 'update_loading_message', 'create_chat_artifact', 'delete_chat_artifact')
     create_max_copilot_skill_chat_question = sgqlc.types.Field(sgqlc.types.non_null(CreateMaxCopilotSkillChatQuestionResponse), graphql_name='createMaxCopilotSkillChatQuestion', args=sgqlc.types.ArgDict((
         ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
         ('copilot_skill_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotSkillId', default=None)),
@@ -919,6 +923,13 @@ class Mutation(sgqlc.types.Type):
         ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
         ('repository_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='repositoryId', default=None)),
         ('skill_name', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='skillName', default=None)),
+))
+    )
+    test_run_copilot_skill = sgqlc.types.Field(sgqlc.types.non_null(MaxMutationResponse), graphql_name='testRunCopilotSkill', args=sgqlc.types.ArgDict((
+        ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
+        ('skill_name', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='skillName', default=None)),
+        ('nl', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='nl', default=None)),
+        ('parameters', sgqlc.types.Arg(JSON, graphql_name='parameters', default=None)),
 ))
     )
     reload_dataset = sgqlc.types.Field(sgqlc.types.non_null(MaxMutationResponse), graphql_name='reloadDataset', args=sgqlc.types.ArgDict((

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -99,6 +99,18 @@ def mutation_import_copilot_skill_from_zip():
     return _op
 
 
+def mutation_import_skill_from_repo():
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='ImportSkillFromRepo', variables=dict(copilotId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), skillName=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), repositoryId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID))))
+    _op.import_skill_from_repo(copilot_id=sgqlc.types.Variable('copilotId'), skill_name=sgqlc.types.Variable('skillName'), repository_id=sgqlc.types.Variable('repositoryId'))
+    return _op
+
+
+def mutation_sync_max_skill_repository():
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='SyncMaxSkillRepository', variables=dict(id=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID))))
+    _op.sync_max_skill_repository(id=sgqlc.types.Variable('id'))
+    return _op
+
+
 def mutation_update_database_name():
     _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='UpdateDatabaseName', variables=dict(databaseId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), name=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String))))
     _op_update_database_name = _op.update_database_name(database_id=sgqlc.types.Variable('databaseId'), name=sgqlc.types.Variable('name'))
@@ -305,9 +317,11 @@ class Mutation:
     delete_dimension = mutation_delete_dimension()
     delete_metric = mutation_delete_metric()
     import_copilot_skill_from_zip = mutation_import_copilot_skill_from_zip()
+    import_skill_from_repo = mutation_import_skill_from_repo()
     queue_chat_question = mutation_queue_chat_question()
     set_max_agent_workflow = mutation_set_max_agent_workflow()
     set_skill_memory = mutation_set_skill_memory()
+    sync_max_skill_repository = mutation_sync_max_skill_repository()
     update_database_description = mutation_update_database_description()
     update_database_kshot_limit = mutation_update_database_kshot_limit()
     update_database_llm_description = mutation_update_database_llm_description()

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -113,7 +113,19 @@ def mutation_sync_max_skill_repository():
 
 def mutation_test_run_copilot_skill():
     _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='TestRunCopilotSkill', variables=dict(copilotId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), skillName=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), nl=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), parameters=sgqlc.types.Arg(_schema.JSON)))
-    _op.test_run_copilot_skill(copilot_id=sgqlc.types.Variable('copilotId'), skill_name=sgqlc.types.Variable('skillName'), nl=sgqlc.types.Variable('nl'), parameters=sgqlc.types.Variable('parameters'))
+    _op_test_run_copilot_skill = _op.test_run_copilot_skill(copilot_id=sgqlc.types.Variable('copilotId'), skill_name=sgqlc.types.Variable('skillName'), nl=sgqlc.types.Variable('nl'), parameters=sgqlc.types.Variable('parameters'))
+    _op_test_run_copilot_skill.success()
+    _op_test_run_copilot_skill.error()
+    _op_test_run_copilot_skill.payload()
+    return _op
+
+
+def mutation_get_test_run_output():
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='GetTestRunOutput', variables=dict(answerId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID))))
+    _op_get_test_run_output = _op.get_test_run_output(answer_id=sgqlc.types.Variable('answerId'))
+    _op_get_test_run_output.success()
+    _op_get_test_run_output.error()
+    _op_get_test_run_output.payload()
     return _op
 
 
@@ -322,6 +334,7 @@ class Mutation:
     create_metric = mutation_create_metric()
     delete_dimension = mutation_delete_dimension()
     delete_metric = mutation_delete_metric()
+    get_test_run_output = mutation_get_test_run_output()
     import_copilot_skill_from_zip = mutation_import_copilot_skill_from_zip()
     import_skill_from_repo = mutation_import_skill_from_repo()
     queue_chat_question = mutation_queue_chat_question()

--- a/answer_rocket/graphql/sdk_operations.py
+++ b/answer_rocket/graphql/sdk_operations.py
@@ -111,6 +111,12 @@ def mutation_sync_max_skill_repository():
     return _op
 
 
+def mutation_test_run_copilot_skill():
+    _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='TestRunCopilotSkill', variables=dict(copilotId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), skillName=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), nl=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), parameters=sgqlc.types.Arg(_schema.JSON)))
+    _op.test_run_copilot_skill(copilot_id=sgqlc.types.Variable('copilotId'), skill_name=sgqlc.types.Variable('skillName'), nl=sgqlc.types.Variable('nl'), parameters=sgqlc.types.Variable('parameters'))
+    return _op
+
+
 def mutation_update_database_name():
     _op = sgqlc.operation.Operation(_schema_root.mutation_type, name='UpdateDatabaseName', variables=dict(databaseId=sgqlc.types.Arg(sgqlc.types.non_null(_schema.UUID)), name=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String))))
     _op_update_database_name = _op.update_database_name(database_id=sgqlc.types.Variable('databaseId'), name=sgqlc.types.Variable('name'))
@@ -322,6 +328,7 @@ class Mutation:
     set_max_agent_workflow = mutation_set_max_agent_workflow()
     set_skill_memory = mutation_set_skill_memory()
     sync_max_skill_repository = mutation_sync_max_skill_repository()
+    test_run_copilot_skill = mutation_test_run_copilot_skill()
     update_database_description = mutation_update_database_description()
     update_database_kshot_limit = mutation_update_database_kshot_limit()
     update_database_llm_description = mutation_update_database_llm_description()


### PR DESCRIPTION
Added a few functions for claude to build and test skills in a repo
sync repo - same thing as hitting sync button in UI
import skill from repo - uses skill name to add skill to copilot from the skills in a specified repo
test run skill - runs skill similar to studio question run, no chat pipeline
get test output - retrieves response of test run, claude will use this to effectively poll the response