### PR TITLE
Resolve csv-df gzip warning

### DIFF
--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -653,7 +653,7 @@ class Chat:
         df_dicts = result.chat_entry.answer.report_results[0].gzipped_dataframes_and_metadata
 
         def transform_df(df_dict: dict):
-            df = pd.read_csv(io.StringIO(df_dict.get("df")), compression='gzip')
+            df = pd.read_csv(io.StringIO(df_dict.get("df")))
             df.max_metadata.hydrate(df_dict.get("metadata", {}))
             return {**df_dict, "df": df}
 


### PR DESCRIPTION
This compression flag does nothing when reading csv to df, so we end up with a bunch of these warnings in the logs:

``````
/usr/local/lib/python3.10/site-packages/answer_rocket/chat.py:620: RuntimeWarning: compression has no effect when passing a non-binary object as input.
  df = pd.read_csv(io.StringIO(df_dict.get("df")), compression='gzip')
``````

Putting up this fix to reduce log spam.
  
  