### PR TITLE
Add Admin-Gated allChatThreads Endpoint

### DIFF
--- a/answer_rocket/chat.py
+++ b/answer_rocket/chat.py
@@ -127,6 +127,41 @@ class Chat:
 
         return result.user_chat_threads
 
+    def get_all_threads(self, copilot_id: str, start_date: datetime = None, end_date: datetime = None):
+        """
+        Fetches threads for a copilot across ALL users. Admin / query-browser only.
+        :param copilot_id: the ID of the copilot to fetch threads for
+        :param start_date: the start date of the range to fetch threads for
+        :param end_date: the end date of the range to fetch threads for
+        :return: a list of chat threads across all users
+        """
+
+        def format_date(input_date: datetime):
+            if not input_date:
+                return None
+            return str(input_date.isoformat()).replace(" ", "T") + "Z"
+
+        get_all_threads_query_args = {
+            'copilotId': UUID(copilot_id),
+            'startDate': format_date(start_date),
+            'endDate': format_date(end_date),
+        }
+        get_all_threads_query_vars = {
+            'copilot_id': Arg(non_null(UUID)),
+            'start_date': Arg(DateTime),
+            'end_date': Arg(DateTime),
+        }
+        operation = self.gql_client.query(variables=get_all_threads_query_vars)
+        get_all_threads_query = operation.all_chat_threads(
+            copilot_id=Variable('copilot_id'),
+            start_date=Variable('start_date'),
+            end_date=Variable('end_date'),
+        )
+
+        result = self.gql_client.submit(operation, get_all_threads_query_args)
+
+        return result.all_chat_threads
+
     def get_entries(self, thread_id: str, offset: int = None, limit: int = None):
         """
         Fetches all entries for a given thread.

--- a/answer_rocket/graphql/schema.py
+++ b/answer_rocket/graphql/schema.py
@@ -1747,7 +1747,7 @@ class ParameterDefinition(sgqlc.types.Type):
 
 class Query(sgqlc.types.Type):
     __schema__ = schema
-    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilots', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'get_copilot_hydrated_reports', 'get_async_skill_run_status', 'get_copilot_test_run', 'get_paged_copilot_test_runs', 'get_copilot_question_folders', 'get_max_agent_workflow', 'execute_sql_query', 'execute_rql_query', 'get_databases', 'get_database', 'get_database_tables', 'get_dataset_id', 'get_dataset', 'get_dataset2', 'get_datasets', 'get_domain_object', 'get_domain_object_by_name', 'get_grounded_value', 'get_database_kshots', 'get_database_kshot_by_id', 'get_dataset_kshots', 'get_dataset_kshot_by_id', 'run_max_sql_gen', 'run_sql_ai', 'generate_visualization', 'llmapi_config_for_sdk', 'generate_embeddings', 'get_max_llm_prompt', 'user_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries', 'skill_memory', 'chat_completion', 'narrative_completion', 'narrative_completion_with_prompt', 'sql_completion', 'research_completion', 'chat_completion_with_prompt', 'research_completion_with_prompt', 'get_chat_artifact', 'get_chat_artifacts', 'get_dynamic_layout', 'get_tracked_dimension_values', 'get_all_tracked_dimension_values', 'observability_traces')
+    __field_names__ = ('ping', 'current_user', 'get_copilot_skill_artifact_by_path', 'get_copilots', 'get_copilot_info', 'get_copilot_skill', 'run_copilot_skill', 'get_skill_components', 'get_copilot_hydrated_reports', 'get_async_skill_run_status', 'get_copilot_test_run', 'get_paged_copilot_test_runs', 'get_copilot_question_folders', 'get_max_agent_workflow', 'execute_sql_query', 'execute_rql_query', 'get_databases', 'get_database', 'get_database_tables', 'get_dataset_id', 'get_dataset', 'get_dataset2', 'get_datasets', 'get_domain_object', 'get_domain_object_by_name', 'get_grounded_value', 'get_database_kshots', 'get_database_kshot_by_id', 'get_dataset_kshots', 'get_dataset_kshot_by_id', 'run_max_sql_gen', 'run_sql_ai', 'generate_visualization', 'llmapi_config_for_sdk', 'generate_embeddings', 'get_max_llm_prompt', 'user_chat_threads', 'all_chat_threads', 'user_chat_entries', 'chat_thread', 'chat_entry', 'user', 'all_chat_entries', 'skill_memory', 'chat_completion', 'narrative_completion', 'narrative_completion_with_prompt', 'sql_completion', 'research_completion', 'chat_completion_with_prompt', 'research_completion_with_prompt', 'get_chat_artifact', 'get_chat_artifacts', 'get_dynamic_layout', 'get_tracked_dimension_values', 'get_all_tracked_dimension_values', 'observability_traces')
     ping = sgqlc.types.Field(String, graphql_name='ping')
     current_user = sgqlc.types.Field(MaxUser, graphql_name='currentUser')
     get_copilot_skill_artifact_by_path = sgqlc.types.Field(CopilotSkillArtifact, graphql_name='getCopilotSkillArtifactByPath', args=sgqlc.types.ArgDict((
@@ -1930,6 +1930,12 @@ class Query(sgqlc.types.Type):
 ))
     )
     user_chat_threads = sgqlc.types.Field(sgqlc.types.list_of(JSON), graphql_name='userChatThreads', args=sgqlc.types.ArgDict((
+        ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
+        ('start_date', sgqlc.types.Arg(DateTime, graphql_name='startDate', default=None)),
+        ('end_date', sgqlc.types.Arg(DateTime, graphql_name='endDate', default=None)),
+))
+    )
+    all_chat_threads = sgqlc.types.Field(sgqlc.types.list_of(JSON), graphql_name='allChatThreads', args=sgqlc.types.ArgDict((
         ('copilot_id', sgqlc.types.Arg(sgqlc.types.non_null(UUID), graphql_name='copilotId', default=None)),
         ('start_date', sgqlc.types.Arg(DateTime, graphql_name='startDate', default=None)),
         ('end_date', sgqlc.types.Arg(DateTime, graphql_name='endDate', default=None)),


### PR DESCRIPTION
Adds the ability to fetch a copilot's chat threads across all users, with optional date-range filtering.